### PR TITLE
AI Agent v1.1 (#54): OpenAI接続＋厳密JSON/フォールバック/監査の最小導入 と 設計ドキュメント(v1.2 #55) 追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ lerna-debug.log*
 .env.local
 .env.development.local
 .env.test.local
+.env.test
 .env.production.local
 
 # IDE

--- a/api/.env.example
+++ b/api/.env.example
@@ -33,11 +33,24 @@ MAIL_FROM=noreply@example.com
 TZ=Asia/Tokyo
 
 # AI Agent Settings
+# Switch between 'mock' (default) and 'openai' for real OpenAI calls
+AI_AGENT_MODE=mock
 OPENAI_API_KEY=your-openai-api-key-here
 OPENAI_MODEL=gpt-4-turbo-preview
 OPENAI_TEMPERATURE=0.7
 OPENAI_MAX_TOKENS=2000
 OPENAI_TIMEOUT_MS=30000
+
+# OpenAI per-user request cap used by OpenAIService.checkRateLimit
+OPENAI_RATE_LIMIT_PER_USER=100
+
+# Session rate limits used by AIConfigService.getSessionRateLimit
+SESSION_RATE_LIMIT_PER_MINUTE=20
+SESSION_RATE_LIMIT_PER_HOUR=100
+SESSION_RATE_LIMIT_PER_DAY=500
+
+# Feature flags (AI features can be toggled via AI_FEATURE_* envs)
+AI_FEATURE_AI_AGENT=true
 
 # AI Rate Limiting
 AI_RATE_LIMIT_REQUESTS_PER_MINUTE=20

--- a/api/.env.test
+++ b/api/.env.test
@@ -9,3 +9,84 @@ ENABLE_WEBSOCKET=false
 # Redis for testing (optional)
 REDIS_HOST="localhost"
 REDIS_PORT="6379"JWT_SECRET=test-secret
+
+# JWT
+JWT_SECRET=your-secret-key-here-change-in-production
+JWT_EXPIRES_IN=7d
+
+# Storage
+STORAGE_TYPE=minio
+MINIO_ENDPOINT=localhost
+MINIO_PORT=9000
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin
+MINIO_USE_SSL=false
+MINIO_BUCKET=process-todo
+
+# Mail (optional)
+MAIL_HOST=smtp.example.com
+MAIL_PORT=587
+MAIL_USER=
+MAIL_PASSWORD=
+MAIL_FROM=noreply@example.com
+
+# Timezone
+TZ=Asia/Tokyo
+
+# AI Agent Settings
+# Switch between 'mock' (default) and 'openai' for real OpenAI calls
+AI_AGENT_MODE=openai
+# OPENAI_API_KEY intentionally left blank for tests to avoid secret scanning; set via CI or local env
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4-turbo-preview
+OPENAI_TEMPERATURE=0.7
+OPENAI_MAX_TOKENS=2000
+OPENAI_TIMEOUT_MS=30000
+
+# OpenAI per-user request cap used by OpenAIService.checkRateLimit
+OPENAI_RATE_LIMIT_PER_USER=100
+
+# Session rate limits used by AIConfigService.getSessionRateLimit
+SESSION_RATE_LIMIT_PER_MINUTE=20
+SESSION_RATE_LIMIT_PER_HOUR=100
+SESSION_RATE_LIMIT_PER_DAY=500
+
+# Feature flags (AI features can be toggled via AI_FEATURE_* envs)
+AI_FEATURE_AI_AGENT=true
+
+# Session rate limits used by AIConfigService.getSessionRateLimit
+SESSION_RATE_LIMIT_PER_MINUTE=20
+SESSION_RATE_LIMIT_PER_HOUR=100
+SESSION_RATE_LIMIT_PER_DAY=500
+
+# Feature flags (AI features can be toggled via AI_FEATURE_* envs)
+AI_FEATURE_AI_AGENT=true
+
+# AI Rate Limiting
+AI_RATE_LIMIT_REQUESTS_PER_MINUTE=20
+AI_RATE_LIMIT_TOKENS_PER_MINUTE=40000
+AI_MAX_CONCURRENT_SESSIONS=10
+
+# AI Cache Settings
+AI_CACHE_TTL_SECONDS=86400
+AI_SESSION_TIMEOUT_MINUTES=60
+AI_SESSION_MAX_DURATION_MINUTES=180
+
+# Web Search Settings
+WEB_SEARCH_API_KEY=your-search-api-key-here
+WEB_SEARCH_ENGINE_ID=your-search-engine-id
+WEB_SEARCH_MAX_RESULTS=10
+WEB_SEARCH_CACHE_TTL_HOURS=24
+
+# Background Job Settings
+BULL_REDIS_HOST=localhost
+BULL_REDIS_PORT=6379
+BULL_JOB_DEFAULT_RETRIES=3
+BULL_JOB_DEFAULT_BACKOFF_DELAY=5000
+BULL_JOB_REMOVE_ON_COMPLETE=100
+BULL_JOB_REMOVE_ON_FAIL=50
+
+# Monitoring & Logging
+AI_ENABLE_USAGE_TRACKING=true
+AI_LOG_LEVEL=info
+AI_ENABLE_DEBUG_MODE=false

--- a/api/nest-cli.json
+++ b/api/nest-cli.json
@@ -1,9 +1,12 @@
 {
+  "$schema": "https://json.schemastore.org/nest-cli",
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
     "webpack": false,
-    "tsConfigPath": "tsconfig.json"
+    "tsConfigPath": "tsconfig.json",
+    "builder": "swc",
+    "typeCheck": false
   }
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -52,7 +52,7 @@
         "@nestjs/cli": "^10.3.0",
         "@nestjs/testing": "^10.3.0",
         "@swc/cli": "^0.3.14",
-        "@swc/core": "^1.3.107",
+        "@swc/core": "^1.13.5",
         "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
@@ -3162,15 +3162,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.3.tgz",
-      "integrity": "sha512-ZaDETVWnm6FE0fc+c2UE8MHYVS3Fe91o5vkmGfgwGXFbxYvAjKSqxM/j4cRc9T7VZNSJjriXq58XkfCp3Y6f+w==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.5.tgz",
+      "integrity": "sha512-WezcBo8a0Dg2rnR82zhwoR6aRNxeTGfK5QCD6TQ+kg3xx/zNT02s/0o+81h/3zhvFSB24NtqEr8FTw88O5W/JQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.23"
+        "@swc/types": "^0.1.24"
       },
       "engines": {
         "node": ">=10"
@@ -3180,16 +3180,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.13.3",
-        "@swc/core-darwin-x64": "1.13.3",
-        "@swc/core-linux-arm-gnueabihf": "1.13.3",
-        "@swc/core-linux-arm64-gnu": "1.13.3",
-        "@swc/core-linux-arm64-musl": "1.13.3",
-        "@swc/core-linux-x64-gnu": "1.13.3",
-        "@swc/core-linux-x64-musl": "1.13.3",
-        "@swc/core-win32-arm64-msvc": "1.13.3",
-        "@swc/core-win32-ia32-msvc": "1.13.3",
-        "@swc/core-win32-x64-msvc": "1.13.3"
+        "@swc/core-darwin-arm64": "1.13.5",
+        "@swc/core-darwin-x64": "1.13.5",
+        "@swc/core-linux-arm-gnueabihf": "1.13.5",
+        "@swc/core-linux-arm64-gnu": "1.13.5",
+        "@swc/core-linux-arm64-musl": "1.13.5",
+        "@swc/core-linux-x64-gnu": "1.13.5",
+        "@swc/core-linux-x64-musl": "1.13.5",
+        "@swc/core-win32-arm64-msvc": "1.13.5",
+        "@swc/core-win32-ia32-msvc": "1.13.5",
+        "@swc/core-win32-x64-msvc": "1.13.5"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -3201,9 +3201,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.3.tgz",
-      "integrity": "sha512-ux0Ws4pSpBTqbDS9GlVP354MekB1DwYlbxXU3VhnDr4GBcCOimpocx62x7cFJkSpEBF8bmX8+/TTCGKh4PbyXw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.5.tgz",
+      "integrity": "sha512-lKNv7SujeXvKn16gvQqUQI5DdyY8v7xcoO3k06/FJbHJS90zEwZdQiMNRiqpYw/orU543tPaWgz7cIYWhbopiQ==",
       "cpu": [
         "arm64"
       ],
@@ -3218,9 +3218,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.3.tgz",
-      "integrity": "sha512-p0X6yhxmNUOMZrbeZ3ZNsPige8lSlSe1llllXvpCLkKKxN/k5vZt1sULoq6Nj4eQ7KeHQVm81/+AwKZyf/e0TA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.5.tgz",
+      "integrity": "sha512-ILd38Fg/w23vHb0yVjlWvQBoE37ZJTdlLHa8LRCFDdX4WKfnVBiblsCU9ar4QTMNdeTBEX9iUF4IrbNWhaF1Ng==",
       "cpu": [
         "x64"
       ],
@@ -3235,9 +3235,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.3.tgz",
-      "integrity": "sha512-OmDoiexL2fVWvQTCtoh0xHMyEkZweQAlh4dRyvl8ugqIPEVARSYtaj55TBMUJIP44mSUOJ5tytjzhn2KFxFcBA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.5.tgz",
+      "integrity": "sha512-Q6eS3Pt8GLkXxqz9TAw+AUk9HpVJt8Uzm54MvPsqp2yuGmY0/sNaPPNVqctCX9fu/Nu8eaWUen0si6iEiCsazQ==",
       "cpu": [
         "arm"
       ],
@@ -3252,9 +3252,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.3.tgz",
-      "integrity": "sha512-STfKku3QfnuUj6k3g9ld4vwhtgCGYIFQmsGPPgT9MK/dI3Lwnpe5Gs5t1inoUIoGNP8sIOLlBB4HV4MmBjQuhw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.5.tgz",
+      "integrity": "sha512-aNDfeN+9af+y+M2MYfxCzCy/VDq7Z5YIbMqRI739o8Ganz6ST+27kjQFd8Y/57JN/hcnUEa9xqdS3XY7WaVtSw==",
       "cpu": [
         "arm64"
       ],
@@ -3269,9 +3269,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.3.tgz",
-      "integrity": "sha512-bc+CXYlFc1t8pv9yZJGus372ldzOVscBl7encUBlU1m/Sig0+NDJLz6cXXRcFyl6ABNOApWeR4Yl7iUWx6C8og==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.5.tgz",
+      "integrity": "sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==",
       "cpu": [
         "arm64"
       ],
@@ -3286,9 +3286,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.3.tgz",
-      "integrity": "sha512-dFXoa0TEhohrKcxn/54YKs1iwNeW6tUkHJgXW33H381SvjKFUV53WR231jh1sWVJETjA3vsAwxKwR23s7UCmUA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.5.tgz",
+      "integrity": "sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==",
       "cpu": [
         "x64"
       ],
@@ -3303,9 +3303,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.3.tgz",
-      "integrity": "sha512-ieyjisLB+ldexiE/yD8uomaZuZIbTc8tjquYln9Quh5ykOBY7LpJJYBWvWtm1g3pHv6AXlBI8Jay7Fffb6aLfA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.5.tgz",
+      "integrity": "sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==",
       "cpu": [
         "x64"
       ],
@@ -3320,9 +3320,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.3.tgz",
-      "integrity": "sha512-elTQpnaX5vESSbhCEgcwXjpMsnUbqqHfEpB7ewpkAsLzKEXZaK67ihSRYAuAx6ewRQTo7DS5iTT6X5aQD3MzMw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.5.tgz",
+      "integrity": "sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==",
       "cpu": [
         "arm64"
       ],
@@ -3337,9 +3337,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.3.tgz",
-      "integrity": "sha512-nvehQVEOdI1BleJpuUgPLrclJ0TzbEMc+MarXDmmiRFwEUGqj+pnfkTSb7RZyS1puU74IXdK/YhTirHurtbI9w==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.5.tgz",
+      "integrity": "sha512-C5Yi/xIikrFUzZcyGj9L3RpKljFvKiDMtyDzPKzlsDrKIw2EYY+bF88gB6oGY5RGmv4DAX8dbnpRAqgFD0FMEw==",
       "cpu": [
         "ia32"
       ],
@@ -3354,9 +3354,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.3.tgz",
-      "integrity": "sha512-A+JSKGkRbPLVV2Kwx8TaDAV0yXIXm/gc8m98hSkVDGlPBBmydgzNdWy3X7HTUBM7IDk7YlWE7w2+RUGjdgpTmg==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.5.tgz",
+      "integrity": "sha512-YrKdMVxbYmlfybCSbRtrilc6UA8GF5aPmGKBdPvjrarvsmf4i7ZHGCEnLtfOMd3Lwbs2WUZq3WdMbozYeLU93Q==",
       "cpu": [
         "x64"
       ],

--- a/api/package.json
+++ b/api/package.json
@@ -72,7 +72,7 @@
     "@nestjs/cli": "^10.3.0",
     "@nestjs/testing": "^10.3.0",
     "@swc/cli": "^0.3.14",
-    "@swc/core": "^1.3.107",
+    "@swc/core": "^1.13.5",
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -23,6 +23,7 @@ import { AIConfigModule } from './config/ai-config.module';
 import { QueueModule } from './infrastructure/queue/queue.module';
 import { ProcessorsModule } from './infrastructure/processors/processors.module';
 import { WebSocketModule } from './infrastructure/websocket/websocket.module';
+import { RealtimeModule } from './infrastructure/gateways/realtime.module';
 import { AIAgentModule } from './application/usecases/ai-agent/ai-agent.module';
 
 @Module({
@@ -37,6 +38,7 @@ import { AIAgentModule } from './application/usecases/ai-agent/ai-agent.module';
     QueueModule,
     ProcessorsModule,
     WebSocketModule,
+    RealtimeModule,
     AIAgentModule,
     ProcessTemplateModule,
     CaseModule,

--- a/api/src/application/interfaces/ai-agent/ai-conversation-responder.interface.ts
+++ b/api/src/application/interfaces/ai-agent/ai-conversation-responder.interface.ts
@@ -1,0 +1,26 @@
+export interface ConversationSessionInput {
+  sessionId: string;
+  context: Record<string, any>;
+  conversationHistory: Array<{
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+    timestamp: Date;
+    metadata?: Record<string, any>;
+  }>;
+}
+
+export interface ConversationProcessResult {
+  response: string;
+  requirementsExtracted: boolean;
+  extractedRequirements?: any[];
+}
+
+export interface AIConversationResponder {
+  processMessage(
+    session: ConversationSessionInput,
+    message: string,
+  ): Promise<ConversationProcessResult>;
+}
+
+export const AI_CONVERSATION_RESPONDER = 'AI_CONVERSATION_RESPONDER';
+

--- a/api/src/application/interfaces/ai-agent/ai-conversation-responder.interface.ts
+++ b/api/src/application/interfaces/ai-agent/ai-conversation-responder.interface.ts
@@ -13,6 +13,8 @@ export interface ConversationProcessResult {
   response: string;
   requirementsExtracted: boolean;
   extractedRequirements?: any[];
+  tokenCount?: number;
+  estimatedCost?: number;
 }
 
 export interface AIConversationResponder {

--- a/api/src/application/interfaces/ai-agent/types.ts
+++ b/api/src/application/interfaces/ai-agent/types.ts
@@ -17,3 +17,33 @@ export interface UsageDto {
   costUsd?: number;
 }
 
+export enum AiChatSchemaId {
+  ProcessTemplateV1 = 'ai_chat_process_template.v1',
+}
+
+export interface StepTemplateDraft {
+  seq: number;
+  name: string;
+  basis: 'goal' | 'prev';
+  offsetDays: number;
+  requiredArtifacts?: Array<{ kind: string; description?: string }>;
+  dependsOn?: number[];
+}
+
+export interface AiChatProcessTemplateJson {
+  schema: AiChatSchemaId;
+  answer: string;
+  missing_information?: string[];
+  process_template_draft?: {
+    name?: string;
+    stepTemplates: StepTemplateDraft[];
+  };
+}
+
+export interface TemplateDraftParseResult {
+  ok: boolean;
+  schema?: AiChatSchemaId;
+  data?: AiChatProcessTemplateJson;
+  errors?: string[];
+}
+

--- a/api/src/application/interfaces/ai-agent/types.ts
+++ b/api/src/application/interfaces/ai-agent/types.ts
@@ -7,6 +7,11 @@ export interface SessionContextDto {
   additionalContext?: string;
 }
 
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
 export interface UsageDto {
   tokens: number;
   costUsd?: number;

--- a/api/src/application/interfaces/ai-agent/types.ts
+++ b/api/src/application/interfaces/ai-agent/types.ts
@@ -1,0 +1,14 @@
+export interface SessionContextDto {
+  industry?: string;
+  processType?: string;
+  goal?: string;
+  region?: string;
+  compliance?: string;
+  additionalContext?: string;
+}
+
+export interface UsageDto {
+  tokens: number;
+  costUsd?: number;
+}
+

--- a/api/src/application/services/ai-agent/history-assembler.service.spec.ts
+++ b/api/src/application/services/ai-agent/history-assembler.service.spec.ts
@@ -1,0 +1,75 @@
+import { HistoryAssembler } from './history-assembler.service';
+
+class FakeMsg {
+  constructor(private role: any, private content: any) {}
+  getRole() { return this.role; }
+  getContentText() { return typeof this.content === 'string' ? this.content : JSON.stringify(this.content); }
+}
+
+class FakeSession {
+  constructor(private msgs: any[]) {}
+  getConversation() { return this.msgs; }
+}
+
+describe('HistoryAssembler', () => {
+  let assembler: HistoryAssembler;
+  let repo: any;
+
+  beforeEach(() => {
+    repo = { findById: jest.fn() };
+    // @ts-ignore private injection bypass for test
+    assembler = new HistoryAssembler(repo);
+  });
+
+  it('returns empty when session not found', async () => {
+    repo.findById.mockResolvedValue(null);
+    const res = await assembler.build('sid', { windowSize: 5 });
+    expect(res).toEqual([]);
+  });
+
+  it('filters to user/assistant and slices last N, injects system when provided', async () => {
+    const msgs = [
+      new FakeMsg('system', 'ignore'),
+      new FakeMsg('user', 'u1'),
+      new FakeMsg('assistant', 'a1'),
+      new FakeMsg('user', 'u2'),
+      new FakeMsg('assistant', 'a2'),
+    ];
+    repo.findById.mockResolvedValue(new FakeSession(msgs));
+    const res = await assembler.build('sid', { windowSize: 3, systemPrompt: 'SYS' });
+    expect(res[0]).toEqual({ role: 'system', content: 'SYS' });
+    // last 3 of user/assistant: u1,a1,u2,a2 -> slice keeps last 3 items => a1,u2,a2
+    expect(res.slice(1)).toEqual([
+      { role: 'assistant', content: 'a1' },
+      { role: 'user', content: 'u2' },
+      { role: 'assistant', content: 'a2' },
+    ]);
+  });
+
+  it('trims by token budget keeping system and last pair', async () => {
+    const long = 'x'.repeat(5000);
+    const msgs = [
+      new FakeMsg('user', long),
+      new FakeMsg('assistant', long),
+      new FakeMsg('user', 'recent user'),
+      new FakeMsg('assistant', 'recent assistant'),
+    ];
+    repo.findById.mockResolvedValue(new FakeSession(msgs));
+    const res = await assembler.build('sid', { windowSize: 10, systemPrompt: 'SYS', maxTokensBudget: 50 });
+    // Should keep system and last pair at minimum
+    expect(res[0]).toEqual({ role: 'system', content: 'SYS' });
+    expect(res.slice(-2)).toEqual([
+      { role: 'user', content: 'recent user' },
+      { role: 'assistant', content: 'recent assistant' },
+    ]);
+  });
+
+  it('ensures at least last user message if messages < 2', async () => {
+    const msgs = [ new FakeMsg('user', 'only') ];
+    repo.findById.mockResolvedValue(new FakeSession(msgs));
+    const res = await assembler.build('sid', { windowSize: 10 });
+    expect(res.length).toBeGreaterThanOrEqual(1);
+    expect(res[res.length - 1]).toEqual({ role: 'user', content: 'only' });
+  });
+});
+

--- a/api/src/application/services/ai-agent/history-assembler.service.ts
+++ b/api/src/application/services/ai-agent/history-assembler.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class HistoryAssembler {
+  async build(sessionId: string, options: { windowSize: number; maxTokensBudget?: number }): Promise<any[]> {
+    // Stub implementation per PR1 (no logic yet)
+    return [];
+  }
+}
+

--- a/api/src/application/services/ai-agent/history-assembler.service.ts
+++ b/api/src/application/services/ai-agent/history-assembler.service.ts
@@ -1,10 +1,59 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { InterviewSessionRepository } from '../../../domain/ai-agent/repositories/interview-session.repository.interface';
+import { ChatMessage } from '../../interfaces/ai-agent/types';
 
 @Injectable()
 export class HistoryAssembler {
-  async build(sessionId: string, options: { windowSize: number; maxTokensBudget?: number }): Promise<any[]> {
-    // Stub implementation per PR1 (no logic yet)
-    return [];
+  constructor(
+    @Inject('InterviewSessionRepository')
+    private readonly sessionRepository: InterviewSessionRepository,
+  ) {}
+
+  async build(
+    sessionId: string,
+    options: { windowSize: number; maxTokensBudget?: number; systemPrompt?: string },
+  ): Promise<ChatMessage[]> {
+    const session = await this.sessionRepository.findById(sessionId);
+    if (!session) return [];
+
+    const history = session.getConversation();
+
+    // 直近N件（user/assistantのみ）
+    const ua = history.filter((m) => {
+      const role = (m as any).getRole?.();
+      return role === 'user' || role === 'assistant' || role?.toString?.().toLowerCase() === 'user' || role?.toString?.().toLowerCase() === 'assistant';
+    });
+
+    const sliced = ua.slice(Math.max(0, ua.length - options.windowSize));
+
+    const messages: ChatMessage[] = [];
+    if (options.systemPrompt) {
+      messages.push({ role: 'system', content: options.systemPrompt });
+    }
+
+    for (const m of sliced) {
+      const role = (m as any).getRole?.();
+      const roleStr = role && typeof role === 'string' ? (role as 'user'|'assistant') : ((role?.toString?.().toLowerCase?.() as any) ?? 'user');
+      const content = (m as any).getContentText?.() ?? (m as any).getContent?.() ?? '';
+      messages.push({ role: roleStr === 'assistant' ? 'assistant' : 'user', content: String(content) });
+    }
+
+    // トークン予算対応（簡易: utf8/4 換算で予算超過時は先頭から削除）
+    if (options.maxTokensBudget && options.maxTokensBudget > 0) {
+      const estTokens = (s: string) => Math.ceil(new TextEncoder().encode(s).length / 4);
+      let total = messages.reduce((acc, m) => acc + estTokens(m.content), 0);
+      while (total > options.maxTokensBudget && messages.length > 2) {
+        const removed = messages.splice(messages[0].role === 'system' ? 1 : 0, 1);
+        total -= estTokens(removed[0].content);
+      }
+    }
+
+    // 最低限の直近ペア確保
+    if (messages.length < 2 && ua.length > 0) {
+      messages.push({ role: 'user', content: (ua[ua.length - 1] as any).getContentText?.() ?? '' });
+    }
+
+    return messages;
   }
 }
 

--- a/api/src/application/services/ai-agent/llm-output-parser.service.spec.ts
+++ b/api/src/application/services/ai-agent/llm-output-parser.service.spec.ts
@@ -1,0 +1,161 @@
+import { LLMOutputParser } from './llm-output-parser.service';
+import { AiChatSchemaId } from '../../interfaces/ai-agent/types';
+
+const fence = (lang: string, body: string, crlf = false) => {
+  const nl = crlf ? '\r\n' : '\n';
+  return `\`\`\`${lang}${nl}${body}\`\`\``;
+};
+
+describe('LLMOutputParser', () => {
+  let parser: LLMOutputParser;
+  beforeEach(() => {
+    parser = new LLMOutputParser();
+  });
+
+  it('returns MissingFence when no fence exists', () => {
+    const res = parser.extractTemplateJson('hello world');
+    expect(res.ok).toBe(false);
+    expect(res.errors).toContain('MissingFence');
+  });
+
+  it('returns NonJsonFence when fenced block is not an object', () => {
+    const content = fence('json', '[1,2,3]');
+    const res = parser.extractTemplateJson(content);
+    expect(res.ok).toBe(false);
+    expect(res.errors).toContain('NonJsonFence');
+  });
+
+  it('returns FenceTooLarge when fenced JSON exceeds 32KB', () => {
+    const big = 'x'.repeat(33 * 1024);
+    const content = fence('json', `{ "schema": "${AiChatSchemaId.ProcessTemplateV1}", "p": "${big}" }`);
+    const res = parser.extractTemplateJson(content);
+    expect(res.ok).toBe(false);
+    expect(res.errors).toContain('FenceTooLarge');
+  });
+
+  it('returns JsonParseError on malformed JSON (trailing comma)', () => {
+    const content = fence('json', `{ "schema": "${AiChatSchemaId.ProcessTemplateV1}", }`);
+    const res = parser.extractTemplateJson(content);
+    expect(res.ok).toBe(false);
+    expect(res.errors).toContain('JsonParseError');
+  });
+
+  it('returns SchemaMismatch when schema is not expected', () => {
+    const content = fence('json', `{ "schema": "wrong", "answer": "a" }`);
+    const res = parser.extractTemplateJson(content);
+    expect(res.ok).toBe(false);
+    expect(res.errors).toContain('SchemaMismatch');
+  });
+
+  it('fails when seq is not continuous', () => {
+    const body = JSON.stringify({
+      schema: AiChatSchemaId.ProcessTemplateV1,
+      answer: 'ok',
+      process_template_draft: {
+        name: 'n',
+        stepTemplates: [
+          { seq: 1, name: 's1', basis: 'goal', offsetDays: 0 },
+          { seq: 3, name: 's3', basis: 'prev', offsetDays: 1 },
+        ],
+      },
+    });
+    const content = fence('json', body);
+    const res = parser.extractTemplateJson(content);
+    expect(res.ok).toBe(false);
+    expect(res.errors).toContain('ValidationFailed:SeqNotContinuous');
+  });
+
+  it('fails when first step basis is not goal', () => {
+    const body = JSON.stringify({
+      schema: AiChatSchemaId.ProcessTemplateV1,
+      answer: 'ok',
+      process_template_draft: {
+        stepTemplates: [
+          { seq: 1, name: 's1', basis: 'prev', offsetDays: 0 },
+        ],
+      },
+    });
+    const content = fence('json', body);
+    const res = parser.extractTemplateJson(content);
+    expect(res.ok).toBe(false);
+    expect(res.errors).toContain('ValidationFailed:FirstBasisMustBeGoal');
+  });
+
+  it('fails when dependsOn references out of range or future', () => {
+    const body = JSON.stringify({
+      schema: AiChatSchemaId.ProcessTemplateV1,
+      answer: 'ok',
+      process_template_draft: {
+        stepTemplates: [
+          { seq: 1, name: 's1', basis: 'goal', offsetDays: 0 },
+          { seq: 2, name: 's2', basis: 'prev', offsetDays: 1, dependsOn: [99] },
+        ],
+      },
+    });
+    const content = fence('json', body);
+    const res = parser.extractTemplateJson(content);
+    expect(res.ok).toBe(false);
+    expect(res.errors).toContain('ValidationFailed:DependsOnOutOfRange');
+
+    const body2 = JSON.stringify({
+      schema: AiChatSchemaId.ProcessTemplateV1,
+      answer: 'ok',
+      process_template_draft: {
+        stepTemplates: [
+          { seq: 1, name: 's1', basis: 'goal', offsetDays: 0 },
+          { seq: 2, name: 's2', basis: 'prev', offsetDays: 1, dependsOn: [2] },
+        ],
+      },
+    });
+    const content2 = fence('json', body2);
+    const res2 = parser.extractTemplateJson(content2);
+    expect(res2.ok).toBe(false);
+    expect(res2.errors).toContain('ValidationFailed:DependsOnFuture');
+  });
+
+  it('accepts valid minimal draft (empty steps)', () => {
+    const body = JSON.stringify({
+      schema: AiChatSchemaId.ProcessTemplateV1,
+      answer: 'ok',
+      process_template_draft: {
+        name: 'draft',
+        stepTemplates: [],
+      },
+    });
+    const res = parser.extractTemplateJson(fence('json', body));
+    expect(res.ok).toBe(true);
+    expect(res.schema).toBe(AiChatSchemaId.ProcessTemplateV1);
+    expect(res.data?.process_template_draft?.stepTemplates).toEqual([]);
+  });
+
+  it('accepts valid steps and returns data', () => {
+    const body = JSON.stringify({
+      schema: AiChatSchemaId.ProcessTemplateV1,
+      answer: 'ok',
+      process_template_draft: {
+        stepTemplates: [
+          { seq: 1, name: 's1', basis: 'goal', offsetDays: 0 },
+          { seq: 2, name: 's2', basis: 'prev', offsetDays: 1, dependsOn: [1] },
+        ],
+      },
+    });
+    const res = parser.extractTemplateJson(fence('json', body));
+    expect(res.ok).toBe(true);
+    expect(res.data?.process_template_draft?.stepTemplates?.length).toBe(2);
+  });
+
+  it('prefers the last json fence when multiple fences exist', () => {
+    const valid = JSON.stringify({ schema: AiChatSchemaId.ProcessTemplateV1, answer: 'ok' });
+    const multi = fence('txt', 'not json object') + '\n' + fence('json', valid);
+    const res = parser.extractTemplateJson(multi);
+    expect(res.ok).toBe(true);
+  });
+
+  it('handles CRLF fence newlines', () => {
+    const body = JSON.stringify({ schema: AiChatSchemaId.ProcessTemplateV1, answer: 'ok' });
+    const content = fence('json', body, true);
+    const res = parser.extractTemplateJson(content);
+    expect(res.ok).toBe(true);
+  });
+});
+

--- a/api/src/application/services/ai-agent/llm-output-parser.service.ts
+++ b/api/src/application/services/ai-agent/llm-output-parser.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class LLMOutputParser {
+  extractTemplateJson(content: string): { ok: boolean; errors?: string[]; data?: any } {
+    // Stub implementation per PR1 (no logic yet)
+    return { ok: false };
+  }
+}
+

--- a/api/src/application/services/ai-agent/llm-output-parser.service.ts
+++ b/api/src/application/services/ai-agent/llm-output-parser.service.ts
@@ -1,10 +1,90 @@
 import { Injectable } from '@nestjs/common';
+import { AiChatProcessTemplateJson, AiChatSchemaId, TemplateDraftParseResult } from '../../interfaces/ai-agent/types';
 
 @Injectable()
 export class LLMOutputParser {
-  extractTemplateJson(content: string): { ok: boolean; errors?: string[]; data?: any } {
-    // Stub implementation per PR1 (no logic yet)
-    return { ok: false };
+  extractTemplateJson(content: string): TemplateDraftParseResult {
+    if (!content) return { ok: false, errors: ['EmptyContent'] };
+
+    // Find last fenced code block
+    const fenceRegex = /```(\w+)?\n([\s\S]*?)```/g;
+    let lastMatch: RegExpExecArray | null = null;
+    let match: RegExpExecArray | null;
+    while ((match = fenceRegex.exec(content)) !== null) {
+      lastMatch = match;
+    }
+    if (!lastMatch) return { ok: false, errors: ['MissingFence'] };
+
+    const lang = (lastMatch[1] || '').toLowerCase();
+    const code = lastMatch[2].trim();
+
+    // Prefer json-labeled fence; otherwise accept if looks like JSON object
+    if (lang && lang !== 'json') {
+      // Try to find a json fence specifically
+      const jsonFenceRegex = /```json\n([\s\S]*?)```/g;
+      let jsonMatch: RegExpExecArray | null = null;
+      let m: RegExpExecArray | null;
+      while ((m = jsonFenceRegex.exec(content)) !== null) {
+        jsonMatch = m;
+      }
+      if (jsonMatch) {
+        lastMatch = jsonMatch;
+      }
+    }
+
+    const jsonCode = (lastMatch[2] || '').trim();
+
+    if (jsonCode.length > 32 * 1024) return { ok: false, errors: ['FenceTooLarge'] };
+    if (!(jsonCode.startsWith('{') && jsonCode.endsWith('}'))) return { ok: false, errors: ['NonJsonFence'] };
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(jsonCode);
+    } catch (e) {
+      return { ok: false, errors: ['JsonParseError'] };
+    }
+
+    // Schema validation
+    if (parsed.schema !== AiChatSchemaId.ProcessTemplateV1) {
+      return { ok: false, errors: ['SchemaMismatch'] };
+    }
+
+    const data = parsed as AiChatProcessTemplateJson;
+
+    // Validate stepTemplates if present
+    const draft = data.process_template_draft;
+    if (draft && Array.isArray(draft.stepTemplates)) {
+      const steps = draft.stepTemplates;
+      if (steps.length === 0) {
+        // allow empty
+      } else {
+        // seq must be 1..N continuous
+        const seqs = steps.map(s => s.seq).sort((a, b) => a - b);
+        for (let i = 0; i < seqs.length; i++) {
+          if (seqs[i] !== i + 1) {
+            return { ok: false, errors: ['ValidationFailed:SeqNotContinuous'] };
+          }
+        }
+        if (steps[0].basis !== 'goal') {
+          return { ok: false, errors: ['ValidationFailed:FirstBasisMustBeGoal'] };
+        }
+        // dependsOn must reference existing seq and not future
+        for (const s of steps) {
+          if (s.dependsOn) {
+            for (const d of s.dependsOn) {
+              if (d < 1 || d > steps.length) {
+                return { ok: false, errors: ['ValidationFailed:DependsOnOutOfRange'] };
+              }
+              if (d >= s.seq) {
+                return { ok: false, errors: ['ValidationFailed:DependsOnFuture'] };
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return { ok: true, schema: data.schema, data };
   }
 }
 

--- a/api/src/application/services/ai-agent/llm-output-parser.service.ts
+++ b/api/src/application/services/ai-agent/llm-output-parser.service.ts
@@ -6,8 +6,8 @@ export class LLMOutputParser {
   extractTemplateJson(content: string): TemplateDraftParseResult {
     if (!content) return { ok: false, errors: ['EmptyContent'] };
 
-    // Find last fenced code block
-    const fenceRegex = /```(\w+)?\n([\s\S]*?)```/g;
+    // Find last fenced code block (support both LF and CRLF)
+    const fenceRegex = /```(\w+)?\r?\n([\s\S]*?)```/g;
     let lastMatch: RegExpExecArray | null = null;
     let match: RegExpExecArray | null;
     while ((match = fenceRegex.exec(content)) !== null) {
@@ -20,8 +20,8 @@ export class LLMOutputParser {
 
     // Prefer json-labeled fence; otherwise accept if looks like JSON object
     if (lang && lang !== 'json') {
-      // Try to find a json fence specifically
-      const jsonFenceRegex = /```json\n([\s\S]*?)```/g;
+      // Try to find a json fence specifically (support CRLF)
+      const jsonFenceRegex = /```json\r?\n([\s\S]*?)```/g;
       let jsonMatch: RegExpExecArray | null = null;
       let m: RegExpExecArray | null;
       while ((m = jsonFenceRegex.exec(content)) !== null) {

--- a/api/src/application/services/ai-agent/openai-responder.service.spec.ts
+++ b/api/src/application/services/ai-agent/openai-responder.service.spec.ts
@@ -1,0 +1,52 @@
+import { OpenAIResponder } from './openai-responder.service';
+import { PromptBuilder } from './prompt-builder.service';
+import { HistoryAssembler } from './history-assembler.service';
+import { AIConfigService } from '../../../infrastructure/ai/ai-config.service';
+import { OpenAIService } from '../../../infrastructure/ai/openai.service';
+
+const session = {
+  sessionId: 'sid',
+  context: { industry: 'Manufacturing', processType: 'Onboarding' },
+} as any;
+
+describe('OpenAIResponder', () => {
+  let responder: OpenAIResponder;
+  let prompt: jest.Mocked<PromptBuilder>;
+  let history: jest.Mocked<HistoryAssembler>;
+  let cfg: jest.Mocked<AIConfigService>;
+  let openai: jest.Mocked<OpenAIService>;
+
+  beforeEach(() => {
+    prompt = { buildSystemPrompt: jest.fn().mockReturnValue('SYS') } as any;
+    history = { build: jest.fn().mockResolvedValue([{ role: 'user', content: 'u1' }]) } as any;
+    cfg = { getMaxTokens: jest.fn().mockReturnValue(256) } as any;
+    openai = {
+      generateResponse: jest.fn().mockResolvedValue({
+        content: 'ok',
+        confidence: 0.9,
+        metadata: { tokensUsed: 123 },
+      } as any),
+    } as any;
+
+    responder = new OpenAIResponder(prompt, history, cfg, openai);
+  });
+
+  it('builds system and history, passes override and previous, maps tokens', async () => {
+    const result = await responder.processMessage(session, 'Hi');
+
+    expect(prompt.buildSystemPrompt).toHaveBeenCalledWith(session.context);
+    expect(history.build).toHaveBeenCalledWith('sid', expect.objectContaining({
+      windowSize: expect.any(Number),
+      maxTokensBudget: expect.any(Number),
+      systemPrompt: 'SYS',
+    }));
+
+    expect(openai.generateResponse).toHaveBeenCalledWith('Hi', expect.objectContaining({
+      previousMessages: [{ role: 'user', content: 'u1' }],
+    }), 'SYS');
+
+    expect(result.response).toBe('ok');
+    expect(result.tokenCount).toBe(123);
+  });
+});
+

--- a/api/src/application/services/ai-agent/openai-responder.service.ts
+++ b/api/src/application/services/ai-agent/openai-responder.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { AIConversationResponder, ConversationSessionInput, ConversationProcessResult } from '../../interfaces/ai-agent/ai-conversation-responder.interface';
+import { PromptBuilder } from './prompt-builder.service';
+import { HistoryAssembler } from './history-assembler.service';
+import { AIConfigService } from '../../../infrastructure/ai/ai-config.service';
+import { OpenAIService } from '../../../infrastructure/ai/openai.service';
+
+@Injectable()
+export class OpenAIResponder implements AIConversationResponder {
+  private readonly logger = new Logger(OpenAIResponder.name);
+
+  constructor(
+    private readonly promptBuilder: PromptBuilder,
+    private readonly historyAssembler: HistoryAssembler,
+    private readonly aiConfig: AIConfigService,
+    private readonly openAI: OpenAIService,
+  ) {}
+
+  async processMessage(session: ConversationSessionInput, message: string): Promise<ConversationProcessResult> {
+    const systemPrompt = this.promptBuilder.buildSystemPrompt(session.context as any);
+
+    const windowSize = 12; // could come from config later
+    const maxTokensBudget = Math.max(200, this.aiConfig.getMaxTokens());
+
+    const messages = await this.historyAssembler.build(session.sessionId, {
+      windowSize,
+      maxTokensBudget,
+      systemPrompt,
+    });
+
+    // append current user message
+    messages.push({ role: 'user', content: message });
+
+    // Call OpenAI using override system prompt and previous messages
+    const previous = messages.filter(m => m.role !== 'user' || m.content !== message).map(m => ({ role: m.role as 'user'|'assistant', content: m.content }));
+
+    const ai = await this.openAI.generateResponse(message, {
+      sessionId: session.sessionId,
+      userId: 0,
+      industry: (session.context as any)?.industry,
+      processType: (session.context as any)?.processType,
+      previousMessages: previous,
+    }, systemPrompt);
+
+    const tokenCount = ai.metadata?.tokensUsed ?? 0;
+
+    return {
+      response: ai.content,
+      requirementsExtracted: false,
+      extractedRequirements: [],
+      tokenCount,
+    };
+  }
+}
+

--- a/api/src/application/services/ai-agent/prompt-builder.service.spec.ts
+++ b/api/src/application/services/ai-agent/prompt-builder.service.spec.ts
@@ -1,0 +1,43 @@
+import { PromptBuilder } from './prompt-builder.service';
+
+describe('PromptBuilder', () => {
+  let builder: PromptBuilder;
+  beforeEach(() => {
+    builder = new PromptBuilder();
+  });
+
+  it('includes fixed Japanese requirements for empty context', () => {
+    const out = builder.buildSystemPrompt({} as any);
+    expect(out).toContain('日本語で簡潔');
+    expect(out).toContain('[文脈]');
+    expect(out).toContain('ポリシー:');
+    expect(out).toContain('出力要件:');
+    expect(out).toContain('ai_chat_process_template.v1');
+    expect(out).toContain('コードフェンス');
+  });
+
+  it('embeds industry/processType/goal/region+compliance/additionalContext', () => {
+    const out = builder.buildSystemPrompt({
+      industry: 'Manufacturing',
+      processType: 'Onboarding',
+      goal: 'Reduce lead time',
+      region: 'JP',
+      compliance: ['PIPA', 'SOX'],
+      additionalContext: 'Pilot project',
+    } as any);
+
+    expect(out).toContain('業界: Manufacturing');
+    expect(out).toContain('プロセス種別: Onboarding');
+    expect(out).toContain('ゴール: Reduce lead time');
+    expect(out).toContain('地域/規制: JP/PIPA, SOX');
+    expect(out).toContain('追加前提: Pilot project');
+  });
+
+  it('formats compliance string or undefined gracefully', () => {
+    const s1 = builder.buildSystemPrompt({ region: 'US', compliance: 'GLBA' } as any);
+    expect(s1).toContain('地域/規制: US/GLBA');
+    const s2 = builder.buildSystemPrompt({ region: 'EU' } as any);
+    expect(s2).toContain('地域/規制: EU/-');
+  });
+});
+

--- a/api/src/application/services/ai-agent/prompt-builder.service.ts
+++ b/api/src/application/services/ai-agent/prompt-builder.service.ts
@@ -4,8 +4,33 @@ import { SessionContextDto } from '../../interfaces/ai-agent/types';
 @Injectable()
 export class PromptBuilder {
   buildSystemPrompt(context: SessionContextDto): string {
-    // Stub implementation per PR1 (no logic yet)
-    return 'System prompt placeholder';
+    const lines: string[] = [];
+    lines.push('あなたは業務プロセスの設計・改善を支援する専門アシスタントです。');
+    lines.push('以下の文脈を前提に、日本語で簡潔かつ構造化（箇条書き中心）して回答してください。');
+    lines.push('');
+    lines.push('[文脈]');
+    if (context?.industry) lines.push(`- 業界: ${context.industry}`);
+    if (context?.processType) lines.push(`- プロセス種別: ${context.processType}`);
+    if (context?.goal) lines.push(`- ゴール: ${context.goal}`);
+    if (context?.region || context?.compliance) {
+      const region = context.region ?? '-';
+      const compliance = Array.isArray((context as any).compliance)
+        ? (context as any).compliance.join(', ')
+        : (context.compliance ?? '-');
+      lines.push(`- 地域/規制: ${region}/${compliance}`);
+    }
+    if (context?.additionalContext) lines.push(`- 追加前提: ${context.additionalContext}`);
+    lines.push('');
+    lines.push('ポリシー:');
+    lines.push('- 不確実な点は想定・前提を明示し、必要な追加情報を最後に箇条書きで尋ねる。');
+    lines.push('- 個人情報・機密情報の再掲や推測は行わない。');
+    lines.push('- 法的/規制の解釈が必要な場合は一般的留意点の範囲で述べるに留める。');
+    lines.push('- 長文化を避け、最大でも3〜6項目の箇条書きを基本とする。');
+    lines.push('');
+    lines.push('出力要件:');
+    lines.push('- 人向け日本語回答の後に、構造化JSON（ai_chat_process_template.v1）をコードフェンス（json）で1個だけ出力すること。');
+    lines.push('- 余計な鍵やコメントは付与しない。厳密なJSONであること。');
+    return lines.join('\n');
   }
 }
 

--- a/api/src/application/services/ai-agent/prompt-builder.service.ts
+++ b/api/src/application/services/ai-agent/prompt-builder.service.ts
@@ -28,8 +28,30 @@ export class PromptBuilder {
     lines.push('- 長文化を避け、最大でも3〜6項目の箇条書きを基本とする。');
     lines.push('');
     lines.push('出力要件:');
-    lines.push('- 人向け日本語回答の後に、構造化JSON（ai_chat_process_template.v1）をコードフェンス（json）で1個だけ出力すること。');
-    lines.push('- 余計な鍵やコメントは付与しない。厳密なJSONであること。');
+    lines.push('- 人向け日本語回答の後に、構造化JSON（schema: "ai_chat_process_template.v1"）をコードフェンス（json）で1個だけ出力する。');
+    lines.push('- JSONは厳密なオブジェクト。コメント、末尾カンマ、追加キー、説明文の混入は禁止（JSON5不可）。');
+    lines.push('- 許可されるトップレベルの鍵: schema, answer, missing_information, process_template_draft のみ。');
+    lines.push('- process_template_draft.stepTemplates の各要素は {seq, name, basis, offsetDays, dependsOn?} のみ。');
+    lines.push('- 制約:');
+    lines.push('  - seq は 1 から始まる連番（1..N）。');
+    lines.push("  - 最初のステップの basis は 'goal'、以降は通常 'prev'。");
+    lines.push('  - offsetDays は数値（日数）。');
+    lines.push('  - dependsOn は過去の seq のみ参照し、存在する番号のみ。');
+    lines.push('- 例（最小構成。値は文脈に合わせて調整すること）:');
+    lines.push('```json');
+    lines.push('{');
+    lines.push('  "schema": "ai_chat_process_template.v1",');
+    lines.push('  "answer": "要約テキスト",');
+    lines.push('  "missing_information": ["不足情報A", "不足情報B"],');
+    lines.push('  "process_template_draft": {');
+    lines.push('    "name": "プロセス名",');
+    lines.push('    "stepTemplates": [');
+    lines.push('      { "seq": 1, "name": "第一ステップ", "basis": "goal", "offsetDays": 0 },');
+    lines.push('      { "seq": 2, "name": "第二ステップ", "basis": "prev", "offsetDays": 7, "dependsOn": [1] }');
+    lines.push('    ]');
+    lines.push('  }');
+    lines.push('}');
+    lines.push('```');
     return lines.join('\n');
   }
 }

--- a/api/src/application/services/ai-agent/prompt-builder.service.ts
+++ b/api/src/application/services/ai-agent/prompt-builder.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { SessionContextDto } from '../../interfaces/ai-agent/types';
+
+@Injectable()
+export class PromptBuilder {
+  buildSystemPrompt(context: SessionContextDto): string {
+    // Stub implementation per PR1 (no logic yet)
+    return 'System prompt placeholder';
+  }
+}
+

--- a/api/src/application/services/ai-agent/template-draft-mapper.service.ts
+++ b/api/src/application/services/ai-agent/template-draft-mapper.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TemplateDraftMapper {
+  toCreateDto(json: any): any {
+    // Stub implementation per PR1 (no logic yet)
+    return null;
+  }
+}
+

--- a/api/src/application/usecases/ai-agent/ai-agent.module.spec.ts
+++ b/api/src/application/usecases/ai-agent/ai-agent.module.spec.ts
@@ -1,0 +1,71 @@
+import { Test } from '@nestjs/testing';
+import { AIAgentModule } from './ai-agent.module';
+import { AI_CONVERSATION_RESPONDER, AIConversationResponder } from '../../interfaces/ai-agent/ai-conversation-responder.interface';
+import { AIConversationService } from '../../../domain/ai-agent/services/ai-conversation.service';
+import { OpenAIResponder } from '../../services/ai-agent/openai-responder.service';
+import { ConfigModule } from '@nestjs/config';
+import { MonitoringModule } from '../../../infrastructure/monitoring/monitoring.module';
+import { InfrastructureModule } from '../../../infrastructure/infrastructure.module';
+import { DomainModule } from '../../../domain/domain.module';
+import { WebSocketModule } from '../../../infrastructure/websocket/websocket.module';
+import { AICacheModule } from '../../../infrastructure/cache/cache.module';
+import { QueueModule } from '../../../infrastructure/queue/queue.module';
+
+// Helper to isolate env changes per test
+const withEnv = async (key: string, value: string, fn: () => Promise<void>) => {
+  const old = process.env[key];
+  process.env[key] = value;
+  try { await fn(); } finally { if (old === undefined) delete process.env[key]; else process.env[key] = old; }
+};
+
+describe('AIAgentModule DI', () => {
+  it('binds AI_CONVERSATION_RESPONDER to AIConversationService when AI_AGENT_MODE=mock', async () => {
+    await withEnv('AI_AGENT_MODE', 'mock', async () => {
+      const moduleRef = await Test.createTestingModule({ imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        // minimal deps so AIAgentModule compiles
+        MonitoringModule,
+        InfrastructureModule,
+        DomainModule,
+        WebSocketModule,
+        AICacheModule,
+        QueueModule,
+        AIAgentModule,
+      ], providers: [
+        { provide: (await import('../../../infrastructure/monitoring/ai-audit.service')).AIAuditService, useValue: { computeConversationHash: jest.fn().mockReturnValue('hash') } },
+        // Provide PromptBuilder/HistoryAssembler since OpenAIResponder is constructed
+        (await import('../../services/ai-agent/prompt-builder.service')).PromptBuilder,
+        (await import('../../services/ai-agent/history-assembler.service')).HistoryAssembler,
+        (await import('../../services/ai-agent/openai-responder.service')).OpenAIResponder,
+      ] }).compile();
+      const impl = moduleRef.get<AIConversationResponder>(AI_CONVERSATION_RESPONDER, { strict: false } as any);
+      // In mock mode we expect conversation service (domain mock)
+      const isMock = impl instanceof AIConversationService;
+      expect(isMock).toBe(true);
+    });
+  });
+
+  it('binds AI_CONVERSATION_RESPONDER to OpenAIResponder when AI_AGENT_MODE=openai', async () => {
+    await withEnv('AI_AGENT_MODE', 'openai', async () => {
+      const moduleRef = await Test.createTestingModule({ imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        MonitoringModule,
+        InfrastructureModule,
+        DomainModule,
+        WebSocketModule,
+        AICacheModule,
+        QueueModule,
+        AIAgentModule,
+      ], providers: [
+        { provide: (await import('../../../infrastructure/monitoring/ai-audit.service')).AIAuditService, useValue: { computeConversationHash: jest.fn().mockReturnValue('hash') } },
+        (await import('../../services/ai-agent/prompt-builder.service')).PromptBuilder,
+        (await import('../../services/ai-agent/history-assembler.service')).HistoryAssembler,
+        (await import('../../services/ai-agent/openai-responder.service')).OpenAIResponder,
+      ] }).compile();
+      const impl = moduleRef.get<AIConversationResponder>(AI_CONVERSATION_RESPONDER, { strict: false } as any);
+      const isOpenAI = impl instanceof OpenAIResponder;
+      expect(isOpenAI).toBe(true);
+    });
+  });
+});
+

--- a/api/src/application/usecases/ai-agent/ai-agent.module.ts
+++ b/api/src/application/usecases/ai-agent/ai-agent.module.ts
@@ -44,6 +44,7 @@ import { FeatureFlagService, AIFeatureFlagGuard } from '../../../infrastructure/
     require('../../../application/services/ai-agent/history-assembler.service').HistoryAssembler,
     require('../../../application/services/ai-agent/llm-output-parser.service').LLMOutputParser,
     require('../../../application/services/ai-agent/template-draft-mapper.service').TemplateDraftMapper,
+    OpenAIResponder,
     FeatureFlagService,
     AIFeatureFlagGuard,
     StartInterviewSessionUseCase,

--- a/api/src/application/usecases/ai-agent/ai-agent.module.ts
+++ b/api/src/application/usecases/ai-agent/ai-agent.module.ts
@@ -15,11 +15,14 @@ import { SearchComplianceRequirementsUseCase } from './search-compliance-require
 import { SearchProcessBenchmarksUseCase } from './search-process-benchmarks.usecase';
 import { KnowledgeBaseModule } from '../knowledge-base/knowledge-base.module';
 import { DomainModule } from '../../../domain/domain.module';
+import { AI_CONVERSATION_RESPONDER } from '../../interfaces/ai-agent/ai-conversation-responder.interface';
+import { AIConversationService } from '../../../domain/ai-agent/services/ai-conversation.service';
 import { InfrastructureModule } from '../../../infrastructure/infrastructure.module';
 import { WebSocketModule } from '../../../infrastructure/websocket/websocket.module';
 import { AICacheModule } from '../../../infrastructure/cache/cache.module';
 import { MonitoringModule } from '../../../infrastructure/monitoring/monitoring.module';
 import { QueueModule } from '../../../infrastructure/queue/queue.module';
+import { FeatureFlagService, AIFeatureFlagGuard } from '../../../infrastructure/security/ai-feature-flag.guard';
 
 @Module({
   imports: [
@@ -34,6 +37,13 @@ import { QueueModule } from '../../../infrastructure/queue/queue.module';
   ],
   controllers: [AIAgentController],
   providers: [
+    // AI Agent helpers (PR1 stubs)
+    require('../../../application/services/ai-agent/prompt-builder.service').PromptBuilder,
+    require('../../../application/services/ai-agent/history-assembler.service').HistoryAssembler,
+    require('../../../application/services/ai-agent/llm-output-parser.service').LLMOutputParser,
+    require('../../../application/services/ai-agent/template-draft-mapper.service').TemplateDraftMapper,
+    FeatureFlagService,
+    AIFeatureFlagGuard,
     StartInterviewSessionUseCase,
     GetInterviewSessionUseCase,
     EndInterviewSessionUseCase,
@@ -46,6 +56,10 @@ import { QueueModule } from '../../../infrastructure/queue/queue.module';
     SearchBestPracticesUseCase,
     SearchComplianceRequirementsUseCase,
     SearchProcessBenchmarksUseCase,
+    {
+      provide: AI_CONVERSATION_RESPONDER,
+      useExisting: AIConversationService,
+    },
   ],
   exports: [
     StartInterviewSessionUseCase,

--- a/api/src/application/usecases/ai-agent/ai-agent.module.ts
+++ b/api/src/application/usecases/ai-agent/ai-agent.module.ts
@@ -17,6 +17,8 @@ import { KnowledgeBaseModule } from '../knowledge-base/knowledge-base.module';
 import { DomainModule } from '../../../domain/domain.module';
 import { AI_CONVERSATION_RESPONDER } from '../../interfaces/ai-agent/ai-conversation-responder.interface';
 import { AIConversationService } from '../../../domain/ai-agent/services/ai-conversation.service';
+import { OpenAIResponder } from '../../services/ai-agent/openai-responder.service';
+import { AIConfigService } from '../../../infrastructure/ai/ai-config.service';
 import { InfrastructureModule } from '../../../infrastructure/infrastructure.module';
 import { WebSocketModule } from '../../../infrastructure/websocket/websocket.module';
 import { AICacheModule } from '../../../infrastructure/cache/cache.module';
@@ -56,9 +58,14 @@ import { FeatureFlagService, AIFeatureFlagGuard } from '../../../infrastructure/
     SearchBestPracticesUseCase,
     SearchComplianceRequirementsUseCase,
     SearchProcessBenchmarksUseCase,
+    // DI切替: 現状は既定をモック（AIConversationService）にし、環境変数でOpenAIResponderへ
     {
       provide: AI_CONVERSATION_RESPONDER,
-      useExisting: AIConversationService,
+      useFactory: (aiConfig: AIConfigService, mock: AIConversationService, openai: OpenAIResponder) => {
+        const mode = process.env.AI_AGENT_MODE || 'mock';
+        return mode === 'openai' ? openai : mock;
+      },
+      inject: [AIConfigService, AIConversationService, OpenAIResponder],
     },
   ],
   exports: [

--- a/api/src/application/usecases/ai-agent/process-user-message.usecase.ts
+++ b/api/src/application/usecases/ai-agent/process-user-message.usecase.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { InterviewSessionRepository } from '../../../domain/ai-agent/repositories/interview-session.repository.interface';
-import { AIConversationService } from '../../../domain/ai-agent/services/ai-conversation.service';
+import { AI_CONVERSATION_RESPONDER, AIConversationResponder } from '../../interfaces/ai-agent/ai-conversation-responder.interface';
 import { ProcessAnalysisService } from '../../../domain/ai-agent/services/process-analysis.service';
 import { AIRateLimitService } from '../../../infrastructure/ai/ai-rate-limit.service';
 import { AIMonitoringService } from '../../../infrastructure/monitoring/ai-monitoring.service';
@@ -20,7 +20,8 @@ export class ProcessUserMessageUseCase {
   constructor(
     @Inject('InterviewSessionRepository')
     private readonly sessionRepository: InterviewSessionRepository,
-    private readonly conversationService: AIConversationService,
+    @Inject(AI_CONVERSATION_RESPONDER)
+    private readonly conversationService: AIConversationResponder,
     private readonly analysisService: ProcessAnalysisService,
     private readonly rateLimitService: AIRateLimitService,
     private readonly monitoringService: AIMonitoringService,

--- a/api/src/application/usecases/ai-agent/process-user-message.usecase.ts
+++ b/api/src/application/usecases/ai-agent/process-user-message.usecase.ts
@@ -70,10 +70,13 @@ export class ProcessUserMessageUseCase {
 
     // Audit hash (no prompt/content persistence)
     try {
-      const conversationForHash = session.getConversation().map(msg => ({
-        role: msg.getRole() as string,
-        content: typeof msg.getContent() === 'string' ? (msg.getContent() as string) : JSON.stringify(msg.getContent()),
-      }));
+      const conversationForHash = session.getConversation().map(msg => {
+        const c = msg.getContent() as unknown;
+        return {
+          role: msg.getRole() as string,
+          content: typeof c === 'string' ? c : JSON.stringify(c),
+        };
+      });
       conversationForHash.push({ role: 'user', content: input.message });
       conversationForHash.push({ role: 'assistant', content: aiResponse.content });
       const hash = this.auditService.computeConversationHash(conversationForHash);

--- a/api/src/application/usecases/ai-agent/process-user-message.usecase.ts
+++ b/api/src/application/usecases/ai-agent/process-user-message.usecase.ts
@@ -209,13 +209,13 @@ export class ProcessUserMessageUseCase {
 
     const result = await this.conversationService.processMessage(conversationSession, message);
     
-    // Convert result to AIResponse
+    // Convert result to AIResponse (use actual token count if provided)
     return {
       content: result.response,
-      suggestedQuestions: [], // AI service doesn't return suggestions yet
-      confidence: 0.85,
-      tokenCount: 100,
-      estimatedCost: 0.001,
+      suggestedQuestions: [],
+      confidence: undefined,
+      tokenCount: result.tokenCount ?? 0,
+      estimatedCost: result.estimatedCost ?? 0,
       error: false,
     };
   }
@@ -281,13 +281,11 @@ export class ProcessUserMessageUseCase {
 
   private createFallbackResponse(): AIResponse {
     return {
-      content: "I apologize, but I'm experiencing technical difficulties at the moment. Please try again in a few moments. If the issue persists, please contact support.",
-      suggestedQuestions: [
-        'Can we try that again?',
-        'What were we discussing?',
-        'Can you help me with something else?',
-      ],
+      content: '現在AI応答の生成で問題が発生しました。しばらくしてから再度お試しください。必要であれば、要件や前提条件をもう一度共有してください。',
+      suggestedQuestions: [],
       confidence: 0,
+      tokenCount: 0,
+      estimatedCost: 0,
       error: true,
     };
   }

--- a/api/src/application/usecases/ai-agent/process-user-message.usecase.ut2.spec.ts
+++ b/api/src/application/usecases/ai-agent/process-user-message.usecase.ut2.spec.ts
@@ -1,0 +1,140 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProcessUserMessageUseCase } from './process-user-message.usecase';
+import { InterviewSessionRepository } from '../../../domain/ai-agent/repositories/interview-session.repository.interface';
+import { AI_CONVERSATION_RESPONDER, AIConversationResponder } from '../../interfaces/ai-agent/ai-conversation-responder.interface';
+import { ProcessAnalysisService } from '../../../domain/ai-agent/services/process-analysis.service';
+import { AIRateLimitService } from '../../../infrastructure/ai/ai-rate-limit.service';
+import { AIMonitoringService } from '../../../infrastructure/monitoring/ai-monitoring.service';
+import { BackgroundJobQueueInterface, JobType } from '../../../infrastructure/queue/background-job-queue.interface';
+import { SocketGateway } from '../../../infrastructure/websocket/socket.gateway';
+import { AICacheService } from '../../../infrastructure/cache/ai-cache.service';
+import { AIAuditService } from '../../../infrastructure/monitoring/ai-audit.service';
+import { LLMOutputParser } from '../../services/ai-agent/llm-output-parser.service';
+import { DomainException } from '../../../domain/exceptions/domain.exception';
+
+class FakeMsg {
+  constructor(private role: any, private content: any) {}
+  getRole() { return this.role; }
+  getContent() { return this.content; }
+  getContentText() { return typeof this.content === 'string' ? this.content : JSON.stringify(this.content); }
+  getTimestamp() { return new Date(); }
+}
+
+class FakeSession {
+  private conversation: any[] = [];
+  constructor(private id: string, private userId: number, private status: any, private ctx: any) {}
+  getSessionIdString() { return this.id; }
+  getUserId() { return this.userId; }
+  getStatus() { return this.status; }
+  isExpired() { return false; }
+  getConversation() { return this.conversation; }
+  getContext() { return this.ctx; }
+  getExtractedRequirements() { return []; }
+  addMessage(m: any) { this.conversation.push(m); }
+}
+
+describe('ProcessUserMessageUseCase (Phase1 behavior)', () => {
+  let useCase: ProcessUserMessageUseCase;
+  let sessionRepository: jest.Mocked<InterviewSessionRepository>;
+  let responder: jest.Mocked<AIConversationResponder>;
+  let analysis: jest.Mocked<ProcessAnalysisService>;
+  let rate: jest.Mocked<AIRateLimitService>;
+  let mon: jest.Mocked<AIMonitoringService>;
+  let queue: jest.Mocked<BackgroundJobQueueInterface>;
+  let socket: jest.Mocked<SocketGateway>;
+  let cache: jest.Mocked<AICacheService>;
+  let audit: jest.Mocked<AIAuditService>;
+  let parser: jest.Mocked<LLMOutputParser>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProcessUserMessageUseCase,
+        { provide: 'InterviewSessionRepository', useValue: { findById: jest.fn(), updateConversation: jest.fn() } },
+        { provide: AI_CONVERSATION_RESPONDER, useValue: { processMessage: jest.fn() } },
+        { provide: ProcessAnalysisService, useValue: { calculateConversationProgress: jest.fn() } },
+        { provide: AIRateLimitService, useValue: { checkRateLimit: jest.fn().mockResolvedValue(true) } },
+        { provide: AIMonitoringService, useValue: { logUsage: jest.fn(), logAIRequest: jest.fn(), logAIError: jest.fn() } },
+        { provide: 'BackgroundJobQueue', useValue: { addJob: jest.fn().mockResolvedValue(undefined) } },
+        { provide: SocketGateway, useValue: { broadcastConversationUpdate: jest.fn() } },
+        { provide: AICacheService, useValue: { cacheConversation: jest.fn().mockResolvedValue(undefined) } },
+        { provide: AIAuditService, useValue: { computeConversationHash: jest.fn().mockReturnValue('hash') } },
+        { provide: LLMOutputParser, useValue: { extractTemplateJson: jest.fn().mockReturnValue({ ok: true }) } },
+      ],
+    }).compile();
+
+    useCase = module.get(ProcessUserMessageUseCase);
+    sessionRepository = module.get('InterviewSessionRepository');
+    responder = module.get(AI_CONVERSATION_RESPONDER);
+    analysis = module.get(ProcessAnalysisService);
+    rate = module.get(AIRateLimitService);
+    mon = module.get(AIMonitoringService);
+    queue = module.get('BackgroundJobQueue');
+    socket = module.get(SocketGateway);
+    cache = module.get(AICacheService);
+    audit = module.get(AIAuditService);
+    parser = module.get(LLMOutputParser);
+  });
+
+  it('happy path reflects tokenCount and Japanese fallback on failures', async () => {
+    const session = new FakeSession('s', 1, 'active', {});
+    (sessionRepository.findById as jest.Mock).mockResolvedValue(session);
+
+    (responder.processMessage as jest.Mock).mockResolvedValue({ response: 'ai-content', tokenCount: 7, requirementsExtracted: false });
+    ;(analysis.calculateConversationProgress as jest.Mock).mockResolvedValue({ completion: 0.4 });
+
+    const out = await useCase.execute({ sessionId: 's', userId: 1, message: 'Hi' } as any);
+
+    expect(mon.logUsage).toHaveBeenCalledWith(1, 7, 0);
+    expect(out.aiResponse.content).toBe('ai-content');
+
+    // Force failure path and ensure Japanese fallback
+    (responder.processMessage as jest.Mock).mockRejectedValueOnce({ response: { status: 400 } });
+    const out2 = await useCase.execute({ sessionId: 's', userId: 1, message: 'Hi' } as any);
+    expect(out2.aiResponse.content).toContain('現在AI応答の生成で問題が発生しました');
+    expect(out2.aiResponse.suggestedQuestions).toEqual([]);
+  });
+
+  it('logs parser success/failure and audit hash', async () => {
+    const session = new FakeSession('s', 1, 'active', {});
+    (sessionRepository.findById as jest.Mock).mockResolvedValue(session);
+
+    // parser ok -> structured_json_ok
+    ;(responder.processMessage as jest.Mock).mockResolvedValueOnce({ response: 'ai-content', tokenCount: 3, requirementsExtracted: false });
+    await useCase.execute({ sessionId: 's', userId: 1, message: 'Hi' } as any);
+    expect(mon.logAIRequest).toHaveBeenCalledWith(1, 'structured_json_ok', 3, 0);
+
+    // parser ng -> logAIError
+    ;(parser.extractTemplateJson as jest.Mock).mockReturnValueOnce({ ok: false, errors: ['Bad'] });
+    ;(responder.processMessage as jest.Mock).mockResolvedValueOnce({ response: 'ai-content2', tokenCount: 4, requirementsExtracted: false });
+    await useCase.execute({ sessionId: 's', userId: 1, message: 'Hi' } as any);
+    expect(mon.logAIError).toHaveBeenCalledWith(1, 'parse_structured_json', expect.any(Error));
+
+    // audit hash logging when non-null
+    expect(mon.logAIRequest).toHaveBeenCalledWith(1, 'audit_hash', 0, 0);
+  });
+
+  it('retries on retryable errors then falls back after retry failure', async () => {
+    const session = new FakeSession('s', 1, 'active', {});
+    (sessionRepository.findById as jest.Mock).mockResolvedValue(session);
+
+    // first: 429 -> retry
+    ;(responder.processMessage as jest.Mock).mockRejectedValueOnce({ response: { status: 429 } });
+    // retry fails
+    ;(responder.processMessage as jest.Mock).mockRejectedValueOnce(new Error('failed'));
+
+    jest.spyOn<any, any>(useCase as any, 'waitForRetry').mockResolvedValue(undefined);
+
+    const out = await useCase.execute({ sessionId: 's', userId: 1, message: 'Hi' } as any);
+    expect(out.aiResponse.content).toContain('現在AI応答の生成で問題が発生しました');
+  });
+
+  it('throws DomainException for invalid inputs and sessions', async () => {
+    await expect(useCase.execute({} as any)).rejects.toThrow(DomainException);
+
+    const session = new FakeSession('s', 2, 'active', {});
+    (sessionRepository.findById as jest.Mock).mockResolvedValue(session);
+    await expect(useCase.execute({ sessionId: 's', userId: 1, message: 'Hi' } as any)).rejects.toThrow(DomainException);
+  });
+});
+

--- a/api/src/infrastructure/ai/openai.service.ts
+++ b/api/src/infrastructure/ai/openai.service.ts
@@ -38,7 +38,7 @@ export class OpenAIService implements AIClientInterface {
     this.temperature = this.configService.get<number>('OPENAI_TEMPERATURE', 0.7);
   }
 
-  async generateResponse(prompt: string, context: AIContext): Promise<AIResponse> {
+  async generateResponse(prompt: string, context: AIContext, overrideSystemPrompt?: string): Promise<AIResponse> {
     if (!this.openai) {
       throw new Error('OpenAI client not initialized. Please configure OPENAI_API_KEY.');
     }
@@ -47,7 +47,7 @@ export class OpenAIService implements AIClientInterface {
       const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
         {
           role: 'system',
-          content: this.buildSystemPrompt(context),
+          content: overrideSystemPrompt ?? this.buildSystemPrompt(context),
         },
       ];
 

--- a/api/src/infrastructure/gateways/realtime.module.ts
+++ b/api/src/infrastructure/gateways/realtime.module.ts
@@ -1,8 +1,24 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { RealtimeGateway } from './realtime.gateway';
+import { SocketAuthGuard } from '../websocket/socket-auth.guard';
 
 @Module({
-  providers: [RealtimeGateway],
+  imports: [
+    ConfigModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: configService.get<string>('JWT_EXPIRES_IN', '7d'),
+        },
+      }),
+    }),
+  ],
+  providers: [RealtimeGateway, SocketAuthGuard],
   exports: [RealtimeGateway],
 })
 export class RealtimeModule {}

--- a/api/src/infrastructure/monitoring/ai-audit.service.spec.ts
+++ b/api/src/infrastructure/monitoring/ai-audit.service.spec.ts
@@ -1,0 +1,25 @@
+import { AIAuditService } from './ai-audit.service';
+import { ConfigService } from '@nestjs/config';
+
+describe('AIAuditService', () => {
+  it('returns null when SALT is absent', () => {
+    const cfg = { get: jest.fn().mockReturnValue(undefined) } as any as ConfigService;
+    const svc = new AIAuditService(cfg);
+    const out = svc.computeConversationHash([{ role: 'user', content: 'hello' }]);
+    expect(out).toBeNull();
+  });
+
+  it('computes stable sha256 hex when SALT is present with normalization', () => {
+    const cfg = { get: jest.fn().mockReturnValue('SALT') } as any as ConfigService;
+    const svc = new AIAuditService(cfg);
+    const msgs = [
+      { role: 'user', content: ' hello\nworld  ' },
+      { role: 'assistant', content: 'x'.repeat(2000) }, // will be trimmed in normalization chain
+    ];
+    const out1 = svc.computeConversationHash(msgs);
+    const out2 = svc.computeConversationHash(msgs);
+    expect(out1).toMatch(/^[a-f0-9]{64}$/);
+    expect(out1).toBe(out2);
+  });
+});
+

--- a/api/src/infrastructure/monitoring/ai-audit.service.ts
+++ b/api/src/infrastructure/monitoring/ai-audit.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'crypto';
+
+@Injectable()
+export class AIAuditService {
+  constructor(private readonly config: ConfigService) {}
+
+  computeConversationHash(messages: Array<{ role: string; content: string }>): string | null {
+    const salt = this.config.get<string>('AI_AUDIT_SALT');
+    if (!salt) return null;
+
+    // Normalize: "role:content\n" concat, collapse whitespace, trim to 1000 chars
+    const normalized = messages
+      .map((m) => `${m.role}:${(m.content || '').toString()}`)
+      .join('\n')
+      .replace(/\s+/g, ' ')
+      .slice(0, 1000);
+
+    const h = createHash('sha256');
+    h.update(salt + normalized);
+    return h.digest('hex');
+  }
+}
+

--- a/api/src/infrastructure/monitoring/monitoring.module.ts
+++ b/api/src/infrastructure/monitoring/monitoring.module.ts
@@ -4,6 +4,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import { AIMonitoringService } from './ai-monitoring.service';
 import { AuditLogService } from './ai-audit-log.decorator';
 import { MetricsService } from './metrics.service';
+import { AIAuditService } from './ai-audit.service';
 
 /**
  * Monitoring Module
@@ -27,11 +28,13 @@ import { MetricsService } from './metrics.service';
     AIMonitoringService,
     AuditLogService,
     MetricsService,
+    AIAuditService,
   ],
   exports: [
     AIMonitoringService,
     AuditLogService,
     MetricsService,
+    AIAuditService,
   ],
 })
 export class MonitoringModule {}

--- a/api/src/infrastructure/websocket/websocket.module.ts
+++ b/api/src/infrastructure/websocket/websocket.module.ts
@@ -6,6 +6,7 @@ import { SocketAuthGuard } from './socket-auth.guard';
 import { GetInterviewSessionUseCase } from '../../application/usecases/ai-agent/get-interview-session.usecase';
 import { AICacheModule } from '../cache/cache.module';
 import { DomainModule } from '../../domain/domain.module';
+import { InfrastructureModule } from '../infrastructure.module';
 
 @Module({
   imports: [
@@ -21,10 +22,11 @@ import { DomainModule } from '../../domain/domain.module';
       }),
     }),
     AICacheModule, // Required for GetInterviewSessionUseCase
-    DomainModule,  // Required for repositories
+    DomainModule,  // Required for domain services
+    InfrastructureModule, // Required for InterviewSessionRepository
   ],
   providers: [
-    SocketGateway, 
+    SocketGateway,
     SocketAuthGuard,
     GetInterviewSessionUseCase, // Added for session status requests
   ],

--- a/api/src/interfaces/controllers/__tests__/ai-agent.controller.spec.ts
+++ b/api/src/interfaces/controllers/__tests__/ai-agent.controller.spec.ts
@@ -15,6 +15,19 @@ import { SearchProcessBenchmarksUseCase } from '../../../application/usecases/ai
 import { AIRateLimitGuard } from '../../guards/ai-rate-limit.guard';
 import { AIFeatureFlagGuard } from '../../../infrastructure/security/ai-feature-flag.guard';
 import { APP_GUARD } from '@nestjs/core';
+// Knowledge Base use cases needed by the controller constructor
+import { GetIndustryTemplatesUseCase } from '../../../application/usecases/knowledge-base/get-industry-templates.usecase';
+import { CreateIndustryTemplateUseCase } from '../../../application/usecases/knowledge-base/create-industry-template.usecase';
+import { UpdateIndustryTemplateUseCase } from '../../../application/usecases/knowledge-base/update-industry-template.usecase';
+import { DeleteIndustryTemplateUseCase } from '../../../application/usecases/knowledge-base/delete-industry-template.usecase';
+import { GetProcessTypesUseCase } from '../../../application/usecases/knowledge-base/get-process-types.usecase';
+import { CreateProcessTypeUseCase } from '../../../application/usecases/knowledge-base/create-process-type.usecase';
+import { UpdateProcessTypeUseCase } from '../../../application/usecases/knowledge-base/update-process-type.usecase';
+import { DeleteProcessTypeUseCase } from '../../../application/usecases/knowledge-base/delete-process-type.usecase';
+import { GetBestPracticesUseCase } from '../../../application/usecases/knowledge-base/get-best-practices.usecase';
+import { CreateBestPracticeUseCase } from '../../../application/usecases/knowledge-base/create-best-practice.usecase';
+import { UpdateBestPracticeUseCase } from '../../../application/usecases/knowledge-base/update-best-practice.usecase';
+import { BulkUpdateBestPracticesUseCase } from '../../../application/usecases/knowledge-base/bulk-update-best-practices.usecase';
 
 // Mock Guards
 const mockAIRateLimitGuard = {
@@ -112,19 +125,24 @@ describe('AIAgentController', () => {
         },
         {
           provide: SearchProcessBenchmarksUseCase,
-          useValue: {
-            execute: jest.fn(),
-          },
+          useValue: { execute: jest.fn() },
         },
+        // Knowledge Base use cases required by controller constructor
+        { provide: GetIndustryTemplatesUseCase, useValue: { execute: jest.fn() } },
+        { provide: CreateIndustryTemplateUseCase, useValue: { execute: jest.fn() } },
+        { provide: UpdateIndustryTemplateUseCase, useValue: { execute: jest.fn() } },
+        { provide: DeleteIndustryTemplateUseCase, useValue: { execute: jest.fn() } },
+        { provide: GetProcessTypesUseCase, useValue: { execute: jest.fn() } },
+        { provide: CreateProcessTypeUseCase, useValue: { execute: jest.fn() } },
+        { provide: UpdateProcessTypeUseCase, useValue: { execute: jest.fn() } },
+        { provide: DeleteProcessTypeUseCase, useValue: { execute: jest.fn() } },
+        { provide: GetBestPracticesUseCase, useValue: { execute: jest.fn() } },
+        { provide: CreateBestPracticeUseCase, useValue: { execute: jest.fn() } },
+        { provide: UpdateBestPracticeUseCase, useValue: { execute: jest.fn() } },
+        { provide: BulkUpdateBestPracticesUseCase, useValue: { execute: jest.fn() } },
         // Guards
-        {
-          provide: AIRateLimitGuard,
-          useValue: mockAIRateLimitGuard,
-        },
-        {
-          provide: AIFeatureFlagGuard,
-          useValue: mockAIFeatureFlagGuard,
-        },
+        { provide: AIRateLimitGuard, useValue: mockAIRateLimitGuard },
+        { provide: AIFeatureFlagGuard, useValue: mockAIFeatureFlagGuard },
       ],
     })
       .overrideGuard(AIRateLimitGuard)

--- a/api/src/interfaces/controllers/ai-agent.controller.ts
+++ b/api/src/interfaces/controllers/ai-agent.controller.ts
@@ -103,7 +103,7 @@ import { AuditLog, AuditAction } from '../../infrastructure/monitoring/ai-audit-
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, AIRateLimitGuard, AIFeatureFlagGuard)
 @FeatureFlag('ai_agent')  // AI機能全体のフィーチャーフラグ
-@Controller('api/ai-agent')
+@Controller('ai-agent')
 export class AIAgentController {
   constructor(
     private readonly startInterviewUseCase: StartInterviewSessionUseCase,
@@ -183,6 +183,35 @@ export class AIAgentController {
       createdAt: result.createdAt,
       updatedAt: result.createdAt,
     };
+  }
+
+  @Get('sessions/current')
+  @ApiOperation({ summary: 'Get current active session for the user' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Current session retrieved successfully',
+    type: SessionResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'No active session found',
+  })
+  async getCurrentSession(
+    @Request() req: any,
+  ): Promise<SessionResponseDto | null> {
+    // Get the most recent active session for the user
+    try {
+      // Note: This is a simplified implementation
+      // In production, you might want to create a dedicated use case
+      // that queries for the user's most recent active session
+      
+      // For now, we return null to indicate no active session
+      // The frontend will handle this by allowing the user to start a new session
+      return null;
+    } catch (error) {
+      console.error('Error getting current session:', error);
+      return null;
+    }
   }
 
   @Get('sessions/:sessionId')

--- a/docs/ver1.2/ai_agent_draft_to_template_integration_design.md
+++ b/docs/ver1.2/ai_agent_draft_to_template_integration_design.md
@@ -1,0 +1,220 @@
+# AIエージェント: 会話出力からPROCESS TODOテンプレート登録までの接続設計（v1.2）
+
+最終更新: 2025-09-09
+
+## 目的
+AIエージェントのチャット応答（ai_chat_process_template.v1 を含む）を起点に、
+- 会話中の構造化JSONを「セッションのテンプレート下書き（Draft）」として保存し、
+- ユーザーの操作で「確定（Finalize）」した際に、既存のPROCESS TODOテンプレートとして登録する、
+までをエンドツーエンドで接続する。既存実装を破壊せず、最小変更で段階導入可能にする。
+
+## 関連（Issue）
+- GitHub Issue #54: 「OpenAI接続のダミー実装解消（v1.1）」
+  - 本IssueはOpenAI接続と最小のプロンプト/パーサ/フォールバック/監査をスコープ。
+  - 本ドキュメントは、その先の「テンプレート取り込み」接続の設計（v1.2）。
+
+## 現状サマリー（確認結果）
+- チャット→OpenAI応答→LLMOutputParserで厳密検証→会話保存→要件抽出ジョブ投入 までは到達。
+- ただし、
+  - 構造化JSON（ai_chat_process_template.v1）をセッションの Draft として保持していない。
+  - finalize（確定）時に ProcessTemplateRepository へ保存していない（履歴保存止まり）。
+- 既存の関連導線・部品：
+  - GenerateTemplateRecommendationsUseCase（推奨案）、
+  - FinalizeTemplateCreationUseCase（検証・並び最適化・履歴保存）、
+  - CreateProcessTemplateUseCase / ProcessTemplateRepository（既存テンプレ作成API）。
+
+## 目標アーキテクチャ（概要）
+1. 会話処理（/messages）で構造化JSONのパースに成功したら、セッションへ Draft を保存。
+2. ユーザーが finalize を呼ぶと、Draft（または推奨案）を CreateProcessTemplateUseCase 経由で正式テンプレート登録。
+3. 履歴（TemplateGenerationHistory）と既存テンプレートIDを相互に関連付け、セッションを完了。
+
+## 既存構造への影響方針
+- エンドポイントの追加は不要。既存の
+  - POST /api/ai-agent/sessions/:id/messages
+  - POST /api/ai-agent/sessions/:id/generate-template
+  - POST /api/ai-agent/sessions/:id/finalize-template
+  を拡張する。
+- 後方互換を維持（レスポンス構造は最小限のフィールド追加で対応）。
+- フィーチャーフラグで段階的に有効化可能。
+
+---
+
+## 詳細設計
+
+### 1) TemplateDraftMapper（実装追加）
+目的:
+- ai_chat_process_template.v1 → セッションの Draft（InterviewSession.GeneratedTemplate）へ変換。
+- Draft / ai_chat → CreateProcessTemplateDto（正式テンプレ登録用）へ変換。
+
+想定API:
+- `toSessionDraft(aiChat: AiChatProcessTemplateJson): GeneratedTemplate`
+- `toCreateDtoFromAiChat(aiChat: AiChatProcessTemplateJson): CreateProcessTemplateDto`
+- `toCreateDtoFromDraft(draft: GeneratedTemplate): CreateProcessTemplateDto`
+
+変換ルール（要点）:
+- name:
+  - ai_chat.process_template_draft.name があれば採用、無ければ `AI Draft (yyyy-MM-dd HH:mm)` 等。
+- steps:
+  - ai_chat.stepTemplates[{ seq, name, basis, offsetDays, dependsOn? }]
+  - Draft（セッション用）: `{ name, description?, duration, dependencies[] }`
+    - duration := offsetDays（暫定。相対日数として扱う）
+    - dependencies := dependsOn（seqの配列）
+- 正式テンプレDTO（CreateProcessTemplateDto）:
+  - stepTemplates[{ seq, name, basis, offsetDays, requiredArtifacts?, dependsOn? }]
+  - basis は seq=1 → 'goal'、以降 'prev' を基本（ai_chat値はLLMOutputParserで検証済）。
+  - offsetDays は Draft.duration をそのまま採用（負値等の細則は別途ポリシーで調整可）。
+
+バリデーション:
+- seq連番/dependsOnは LLMOutputParser が保証。Mapperは変換専念。
+- 値の欠落は既定値で補完し、警告ログのみ（後続でユーザー編集/再生成可能にする）。
+
+
+### 2) 会話時のDraft保存（ProcessUserMessageUseCase 拡張）
+トリガ:
+- OpenAI応答の content に含まれる最後の ```json フェンスの ai_chat_process_template.v1 をパース成功した場合。
+
+処理:
+- `TemplateDraftMapper.toSessionDraft(parsed.data)`
+- `InterviewSessionRepository.updateGeneratedTemplate(sessionId, draft)`
+- WebSocket通知（既存の `notifyTemplateGenerated(sessionId, draft)` を流用、または `notifyDraftUpdated` を新設）
+- 監視ログ: `ai_draft_saved`
+
+互換性:
+- APIレスポンスは現状どおり（本文＋フェンスJSON）。裏でDraftのみ更新。
+
+
+### 3) 確定時の正式テンプレ登録（FinalizeTemplateCreationUseCase 拡張）
+依存注入:
+- `CreateProcessTemplateUseCase`
+- `TemplateDraftMapper`
+
+処理フロー:
+1. セッション取得、`getGeneratedTemplate()` で Draft を解決（または推奨案の同等構造）。
+2. 既存の検証・並び最適化は従来通り（TemplateRecommendationService）。
+3. DTO変換:
+   - `mapper.toCreateDtoFromDraft(finalTemplate)`
+4. 正式テンプレ登録:
+   - `createProcessTemplateUseCase.execute(dto)`
+   - 競合（name重複）は `ConflictException`。UIでのリネーム誘導またはポリシーで自動サフィックスを検討（本設計では例外を返す）。
+5. 履歴更新/セッション完了:
+   - `TemplateGenerationHistoryRepository.markAsUsed(historyId, processTemplateId, modifications?)`
+   - `InterviewSessionRepository.markAsCompleted(sessionId)`
+6. レスポンス拡張（互換維持）:
+   - `processTemplateId` を追加プロパティとして返却可。
+
+
+### 4) 推奨案生成（GenerateTemplateRecommendationsUseCase）との関係
+- 最小構成では現状のままでも接続可能。
+- 強化案（任意）: Draft を文脈に加える（例: Draftの工程を優先/固定）
+  - TemplateRecommendationService へのコンテキスト拡張で対応。
+
+
+### 5) 非同期ジョブ（Processor）補強案（任意）
+- REQUIREMENT_ANALYSIS: 解析結果を `InterviewSessionRepository.updateRequirements` に書き戻し。
+- TEMPLATE_GENERATION: Draft＋要件＋KB＋Webリサーチで案を生成し、`updateGeneratedTemplate` と通知。
+
+---
+
+## データモデル対応表
+
+| 出所 | 構造 | 変換先 |
+|---|---|---|
+| ai_chat_process_template.v1 | `{ answer, process_template_draft: { name?, stepTemplates[{seq,name,basis,offsetDays,dependsOn?}] } }` | Session Draft（`{name, steps[{name,description?,duration,dependencies[]}]}`） |
+| Session Draft / ai_chat | 上記 | CreateProcessTemplateDto（`{ name, stepTemplates[{seq,name,basis,offsetDays,requiredArtifacts?,dependsOn?}] }`） |
+
+備考:
+- requiredArtifacts は将来拡張のため空配列扱い。
+
+---
+
+## APIタッチポイント（変更の有無）
+- 変更なし（エンドポイント追加なし）。内部処理を拡張。
+- Finalize のレスポンスに `processTemplateId` を追加する場合は後方互換のためオプション項目で。
+
+---
+
+## セキュリティ/権限/フラグ
+- 権限: Finalize は実質「テンプレ作成」に相当。AIAgentController 側で Roles/Permissions が必要なら追加（templates:create）。
+- フラグ（任意）:
+  - `AI_FEATURE_TEMPLATE_DRAFT_SAVE`（Draft保存ON/OFF）
+  - `AI_FEATURE_TEMPLATE_AUTO_CREATE`（Finalize時の自動作成ON/OFF）
+
+---
+
+## 監視・ログ・メトリクス
+- 追加アクション:
+  - `ai_draft_saved`（会話中のDraft保存）
+  - `ai_template_created`（正式テンプレ登録）
+  - `ai_template_conflict`（名称競合）
+- 既存の `structured_json_ok` / フォールバックログは維持。
+- dev 環境のメトリクス未登録による警告（例: `Metric 'ai_tokens_used' not found`）は既知。運用導入時に登録・抑制を行う。
+
+---
+
+## 後方互換性
+
+- 既存のチャット応答/会話保存/エラーポリシーを変更しない。
+- Draft保存とテンプレ登録は“付加機能”として動作（フラグで無効化可能）。
+
+---
+
+## テスト計画（抜粋）
+
+- 単体
+  - TemplateDraftMapper: 最小/境界/依存/負のoffsetDays 等の入力→Draft/DTO 期待形。
+  - ProcessUserMessageUseCase: パース成功で `updateGeneratedTemplate` 呼び出し確認。
+  - FinalizeTemplateCreationUseCase: 正常登録/名称競合/検証失敗の分岐。
+
+- 統合
+  - POST /messages → JSON付き応答 → セッションDraft保存 →（必要なら）GETで確認。
+  - POST /finalize-template → 201 + processTemplateId → /process-templates で実体確認。
+
+- E2E（任意）
+  - 会話→Draft→Finalize→テンプレ一覧に表示。
+
+---
+
+## 段階導入プラン
+
+1. TemplateDraftMapper 実装（UT含む）。
+2. ProcessUserMessageUseCase に Draft保存フック（FeatureFlagでON/OFF）。
+3. FinalizeTemplateCreationUseCase に 正式テンプレ登録と履歴更新。
+4. Processor の要件抽出書き戻し（小タスク）。
+5. 監視メトリクスの追加（開発/本番での登録差分を整理）。
+
+---
+
+## 影響範囲（想定ファイル）
+
+- application/services/ai-agent/
+  - `template-draft-mapper.service.ts`（実装）
+  - `prompt-builder.service.ts`（済：出力制約強化）
+
+- application/usecases/ai-agent/
+  - `process-user-message.usecase.ts`（Draft保存処理を追加）
+  - `finalize-template-creation.usecase.ts`（正式テンプレ登録追加）
+  - `generate-template-recommendations.usecase.ts`（任意：Draft活用）
+
+- application/usecases/process-template/
+  - `create-process-template.usecase.ts`（変更なし、注入して呼ぶ）
+
+- domain/ai-agent/repositories/
+  - `interview-session.repository.interface.ts`（`updateGeneratedTemplate` 既存）
+  - `template-generation-history.repository.interface.ts`（`markAsUsed` 既存）
+
+- infrastructure/processors/
+  - `ai-processing.processor.ts`（任意補強）
+
+---
+
+## オープン課題
+
+- Finalize時の名称競合ポリシー（自動サフィックス vs UIでの再入力）。
+- Draft.duration と正式 offsetDays の解釈統一（基準日/負値の扱い）。
+- フロントの編集UIとAPIの境界（Draft編集をフロントで完結させるか、API側でも保持するか）。
+
+---
+
+## 付記
+
+- 本ドキュメントは実装を伴わない設計レポートであり、既存実装を破壊しない前提で段階導入可能な案を示す。実装時は小規模PRに分割し、UT/統合テストで確認する。

--- a/docs/ver1.2/ai_agent_implementation_plan_v1.1.md
+++ b/docs/ver1.2/ai_agent_implementation_plan_v1.1.md
@@ -1,0 +1,124 @@
+## AIエージェント チャット応答 OpenAI 切替 — 実装計画 v1.1 (Draft)
+
+作成日: 2025-09-04
+対象ブランチ: feature/ai-agent-v1.2-openai-chat
+設計準拠: docs/ver1.2/ai_agent_minimal_design_spec.md (v1.1)
+要件準拠: docs/ver1.2/ai_agent_minimal_design_addendum.md (v1.0)
+
+---
+
+### 1. 目的と方針
+- 目的: チャット応答をOpenAI経由に切替し、要件(日本語応答+末尾JSON)と設計v1.1を満たす
+- 方針: 下層から“骨組み→配線→検証→観測”の順で小PRを積み上げ、ロールバック容易性と互換性を維持
+- 非目標(Phase1): 自動テンプレ作成、コスト実値算出、応答キャッシュ
+
+---
+
+### 2. 前提・制約
+- API契約は不変（aiResponse.contentにJSONが添付されるのみ）
+- Feature Flag/DIでモック↔OpenAI切替が可能
+- usage.tokensは実値、costは0(将来導入)
+- JSONは ai_chat_process_template.v1 を厳密検証、失敗時も会話応答は返す（JSONなし）
+
+---
+
+### 3. 作業分割（PR構成）
+
+#### PR1: インターフェイス/DI骨組み（追加のみ、既存動作不変）
+- 目的: コンポーネントのIFを定義し、DIの切替点(AIConversationResponder)を用意
+- 変更:
+  - 型/IF: ChatMessage, OpenAIResponse, SessionContextDto, ProcessMessageInput/Output, AiChatProcessTemplateJson, TemplateDraftParseResult, AiChatSchemaId, AIConversationErrorCode
+  - 新規クラス（雛形・例外を投げないスタブ）: PromptBuilder, HistoryAssembler, LLMOutputParser, TemplateDraftMapper
+  - DIトグル: Token=AIConversationResponder, 実装=MockResponder(現行)/OpenAIResponder(後続), 環境AI_AGENT_MODEで切替（既定mock）
+- 検証: 起動OK、既存のモック応答が変わらない
+- 依存: なし
+
+#### PR2: PromptBuilder/HistoryAssembler 実装
+- 目的: 安定したSystem Promptと履歴N件/予算内メッセージ生成
+- 変更:
+  - PromptBuilder: 要件記述のsystem prompt雛形をcontextで埋め込み（日本語固定）
+  - HistoryAssembler: N=12、utf8_bytes/4の概算でcontextBudgetに収める。古い履歴から間引き。最低限直近のuser/assistantペアは保持
+  - 設定: OPENAI_MAX_TOKENS/履歴N/safetyMargin を設定サービス経由で参照
+- 検証: ユニットで履歴トリミング・context反映・N変更の安定性
+- 依存: PR1
+
+#### PR3: OpenAI配線（AIConversationService差し替え）＋フォールバック
+- 目的: 実際にOpenAIService.generateResponseを呼び、usage.tokensを反映、フォールバックを実装
+- 変更:
+  - OpenAIResponder: PromptBuilder/HistoryAssemblerによりmessagesを構成→OpenAI呼出→content+usage取得→リトライ最大1回→失敗時フォールバック（日本語固定・JSONなし・tokens=0）
+  - UseCase(ProcessUserMessage): usage.tokensに実値反映（costは0）
+  - 切替: AI_AGENT_MODE=openaiで実接続、既定はmock
+- 検証: ユニットで429/5xx/timeout/成功を網羅、スモーク(キー無し時のエラーパス・フォールバック)
+- 依存: PR1, PR2
+
+#### PR4: LLMOutputParser 実装（厳密JSON抽出/検証）
+- 目的: 回答末尾の構造化JSONを確実に抽出・検証・エラー分類
+- 変更:
+  - 抽出: 最後のフェンス優先、jsonラベル優先、フェンス32KB上限
+  - 検証: 厳密JSON（コメント/末尾カンマ不可）、schema一致、stepTemplates連番/値域/seq=1はgoal
+  - エラー分類: MissingFence/NonJsonFence/JsonParseError/SchemaMismatch/ValidationFailed
+  - UseCase: 解析結果はログ/監査に記録（本文非保存）。API応答は従来どおり
+- 検証: ユニットで各エラー分類ケース、結合でOpenAIResponder出力に対する抽出
+- 依存: PR1, PR3（モックでも可だが現実に近いのはPR3後）
+
+#### PR5: 観測/監査/安全装備（最小）
+- 目的: 運用可視性と追跡性を確保
+- 変更:
+  - 監査ハッシュ: 正規化(role:content\n連結→空白圧縮→先頭1000文字)→SHA-256(AI_AUDIT_SALT+normalized)。SALT未設定時は無効化
+  - メトリクス: ai_requests_total, ai_tokens_total, ai_errors_total{type}, ai_fallback_total, ai_retry_total
+  - 切替確認: mock↔openaiの切替動作
+- 検証: ユニット（ハッシュ再現性/SALT有無）、スモーク（メトリクス増分）
+- 依存: PR3, PR4
+
+---
+
+### 4. 依存関係と順序
+- PR1 → PR2 → PR3 → PR4 → PR5（直列推奨）
+- リスク低減のためPR3の前にPR2を完了（入力の安定化）。PR4はPR3後が望ましい
+
+---
+
+### 5. 検証・品質保証
+- ユニットテスト
+  - PR毎に最小完結のテストを追加（履歴トリミング/プロンプト生成/リトライ・フォールバック/JSON抽出と検証/監査ハッシュ）
+- 結合/スモーク
+  - AI_AGENT_MODE=openai で簡易シナリオ（キーなし環境ではフォールバック動作確認）
+- E2E
+  - PR3後に最小E2E: メッセージ送信→応答→会話保存→WebSocket通知（OpenAIServiceはモック）
+- 監視
+  - フォールバック率、平均tokens、失敗種別をダッシュボード監視
+
+---
+
+### 6. ロールバック戦略
+- 即時切替: AI_AGENT_MODE=mock でモックへ戻す
+- 段階導入: ステージングでopenai→問題なければ本番で段階的に有効化
+- PRごと: 小さくマージするため、問題発生時は直近PRのrevertで対処可
+
+---
+
+### 7. リスクと対策
+- LLM出力逸脱→ Parserの厳密検証/最後のフェンス優先/上限サイズ
+- トークン越境→ HistoryAssemblerの予算制御/安全マージン
+- 監査・機微情報→ 本文非保存/ハッシュのみ/エラーカテゴリ分類
+- UX: JSONフェンス露出→ Phase1は許容、将来UI折りたたみ
+
+---
+
+### 8. 完了基準（Phase1）
+- OpenAI経由の応答が返る（日本語、末尾JSONが1つ）
+- 失敗時フォールバック（JSONなし、tokens=0）
+- usage.tokens が実値で記録
+- 監査/メトリクスが最小限稼働
+- 既存UI/API互換（表示崩れなし）
+
+---
+
+### 9. 見積もり（目安）
+- PR1: 0.5〜1日
+- PR2: 1日
+- PR3: 1.5〜2日
+- PR4: 1〜1.5日
+- PR5: 0.5〜1日
+（コードボリューム・レビュー速度に依存）
+

--- a/docs/ver1.2/ai_agent_minimal_design_addendum.md
+++ b/docs/ver1.2/ai_agent_minimal_design_addendum.md
@@ -1,0 +1,324 @@
+## AIエージェント チャット応答 OpenAI 切替 ― 最小設計追補 v1.0 (Draft)
+
+作成日: 2025-09-04
+状態: Draft（レビュー前）
+担当: AI エージェント開発
+
+---
+
+### 目的
+- 現行のモック応答（AIConversationService）を、OpenAI 経由の実応答に切り替える。
+- 品質・安全性・保守性を満たすため、曖昧さを排し、実装前に設計を確定する。
+
+### スコープ（Phase 1）
+- AIConversationService.processMessage → OpenAIService.generateResponse の配線。
+- System Prompt・履歴取り込み・応答形式の確定（日本語・簡潔・構造化）。
+- usage(tokens/cost) の実値記録（cost は導入タイミングを決める）。
+- リトライ/フォールバック、監視・監査の最小方針。
+
+### 非スコープ（将来フェーズ）
+- suggestedQuestions の LLM 生成、confidence 推定の厳密化。
+- 応答キャッシュの有効化、会話要約投入、関数呼び出し・ツール連携。
+
+---
+
+## 1) System Prompt 仕様
+
+#### 目的
+- ドメイン前提/回答方針を固定し、安定した日本語応答と安全性を確保。
+
+#### 仕様（提案）
+- ロール: 業務プロセス設計・テンプレート作成支援アシスタント。
+- 言語: 常に日本語（ユーザーが英語入力でも日本語で返答）。
+- スタイル: 丁寧体、冗長回避、箇条書き優先、具体例は必要最小限。
+- 安全: PII・機密・法的助言は抑制。確信度が低い場合は前提/不確実性を明示し、追質問を促す。
+
+#### System Prompt（雛形）
+- コンテキストは存在する項目のみ箇条書きで埋め込む。
+- 可能であれば「回答 → 次の確認事項」の順で簡潔に提示。
+
+```
+あなたは業務プロセスの設計・改善を支援する専門アシスタントです。
+以下の文脈を前提に、日本語で簡潔かつ構造化（箇条書き中心）して回答してください。
+
+[文脈]
+- 業界: {industry}
+- プロセス種別: {processType}
+- ゴール: {goal}
+- 地域/規制: {region}/{compliance}
+- 追加前提: {additionalContext}
+
+ポリシー:
+- 不確実な点は想定・前提を明示し、必要な追加情報を最後に箇条書きで尋ねる。
+- 個人情報・機密情報の再掲や推測は行わない。
+- 法的/規制の解釈が必要な場合は一般的留意点の範囲で述べるに留める。
+- 長文化を避け、最大でも3〜6項目の箇条書きを基本とする。
+```
+
+レビュー決定事項:
+- [ ] 文面の最終承認
+- [ ] 追加すべき禁止事項/留意点
+
+### 出力フォーマット（必須・後方互換配慮）
+
+- 目的: チャット応答の末尾に、将来のテンプレート生成へ直結可能な厳密JSONを添付し、後工程の変換を容易にする。
+- 互換性: 先頭は人間可読の日本語回答（従来どおり）。末尾に JSON フェンスを付与（UIは無視してもOK、将来パーサで利用）。
+- 形式: 以下の JSON をコードフェンス（言語: json）で必ず添付。
+- スキーマID: "ai_chat_process_template.v1"
+
+JSON スキーマ（概念）:
+
+```json
+{
+  "schema": "ai_chat_process_template.v1",
+  "answer": "日本語の要約回答（Markdown可）",
+  "missing_information": ["次に確認したい事項", "..."],
+  "process_template_draft": {
+    "name": "テンプレート名（任意・無ければ 'Draft from chat'）",
+    "stepTemplates": [
+      {
+        "seq": 1,
+        "name": "ステップ名",
+        "basis": "goal",            // seq=1 は必ず 'goal'
+        "offsetDays": -5,             // basis からの相対日数（整数）。初期は duration を日換算で可
+        "requiredArtifacts": [        // 生成できない場合は空配列
+          { "kind": "要件定義書", "description": "初稿" }
+        ],
+        "dependsOn": []               // 依存は seq の配列（例: [1]）
+      },
+      {
+        "seq": 2,
+        "name": "次工程",
+        "basis": "prev",            // 2以降は 'prev' を推奨
+        "offsetDays": 3,
+        "requiredArtifacts": [],
+        "dependsOn": [1]
+      }
+    ]
+  }
+}
+```
+
+注記:
+
+- seq は 1 からの連番。dependsOn は seq を参照（IDではなく並び）。
+- basis ルール: seq=1 は 'goal'、以降は 'prev' を原則とする（例外が明確な場合のみ 'goal' 可）。
+- offsetDays は日単位整数。時間見積りしかない場合は切上げ/丸め（設計時は切上げ推奨）。
+- requiredArtifacts の kind は簡潔な資産名。説明は任意。
+
+出力例（応答末尾に必ず付与）:
+
+```json
+{
+  "schema": "ai_chat_process_template.v1",
+  "answer": "上位目標に対して、以下の進め方を提案します。\n- 事前準備\n- キックオフ\n- 初期要件定義\n...",
+  "missing_information": ["対象領域の範囲定義", "品質基準(受入条件)"],
+  "process_template_draft": {
+    "name": "SaaS新規立上げ 初期プロセス(ドラフト)",
+    "stepTemplates": [
+      {"seq":1, "name":"事前準備", "basis":"goal", "offsetDays": -14, "requiredArtifacts":[{"kind":"ビジョン文書"}], "dependsOn": []},
+      {"seq":2, "name":"キックオフ", "basis":"prev", "offsetDays": 2, "requiredArtifacts":[], "dependsOn": [1]},
+      {"seq":3, "name":"初期要件定義", "basis":"prev", "offsetDays": 5, "requiredArtifacts":[{"kind":"要件一次版"}], "dependsOn": [2]}
+    ]
+  }
+}
+```
+
+LLMへの指示追加:
+- 「人間向け回答の後に、上記 JSON をコードフェンスで正確に1個だけ出力。不要な文/余計な鍵は追加しない。」
+- 「JSON は厳密に有効な形式。null を返す場合もプロパティ自体を省略せずに空配列/空文字で対応しない（未生成時は process_template_draft 全体を省略可）。」
+
+#### パーサとマッピング規則（LLM JSON → CreateProcessTemplateDto）
+- 入力: 上記 JSON（schema=ai_chat_process_template.v1）。
+- 検証:
+  - schema が一致
+  - stepTemplates は配列、各要素に seq(>=1), name(非空), basis('goal'|'prev'), offsetDays(整数), requiredArtifacts(配列), dependsOn(配列) が存在
+  - seq は 1..N の連番（欠番不可）。seq=1 の basis は 'goal' 固定。
+  - dependsOn は seq の集合に含まれ、循環推定があれば拒否（Create 前に検出）。
+- 変換（ProcessTemplateDraftDto）：
+  - name: process_template_draft.name || 'Draft from chat'
+  - stepTemplates: 各要素を { seq, name, basis, offsetDays, requiredArtifacts, dependsOn } にマップ
+- 例外処理:
+  - 不足項目がある場合はパースを中断し、UI に missing_information を提示（テンプレは保存しない）。
+- ロギング: schema バージョン・検証エラーを監査に残す（本文は保存しない）。
+
+---
+
+## 2) 履歴ポリシー（トークン抑制）
+
+#### 取り込みルール（Phase 1）
+- ウィンドウ: 直近 N=12 メッセージ（user/assistant 合計）。
+- 並び: system → 過去履歴（古→新）→ user（今回の発話）。
+- トークン上限制御: 推定で上限超過しそうな場合は古い履歴から削除。
+- メタデータ（confidence/tokenCount 等）は LLM 入力に含めない。
+
+将来（Phase 2）:
+- 旧履歴の圧縮用に「会話要約メッセージ」を追加し、詳細は破棄。
+
+レビュー決定事項:
+- [ ] N（初期 12）の承認
+- [ ] 上限制御のしきい値（max_tokens と履歴バジェット）
+
+---
+
+## 3) 応答メタデータ（tokens/cost・confidence・suggestedQuestions）
+
+#### tokens/cost（提案）
+- tokens: OpenAI response.usage.total_tokens を採用。
+- cost: モデル単価を環境変数で管理（導入タイミングを選択）。
+  - 例: OPENAI_PRICE_INPUT, OPENAI_PRICE_OUTPUT（USD/token）。実算は prompt/completion で分割可能だが Phase1 は total_tokens × 単価係数でも可。
+- ProcessUserMessageUseCase.logUsage へ実値を渡す（cost 未導入時は 0）。
+
+#### confidence
+- Phase 1: 未設定（undefined）。固定値の廃止。
+- 将来: self-assessment を JSON で返させて採用（OpenAIService 拡張）。
+
+#### suggestedQuestions
+- Phase 1: 空配列。
+- 将来案A: 本回答と同時に JSON で返却。
+- 将来案B: セカンダリプロンプトで生成。
+
+レビュー決定事項:
+- [ ] cost 実装の導入時期（Phase1 で導入/後日）
+- [ ] モデル単価の定義方法
+
+---
+
+## 4) エラー/リトライ/フォールバック
+
+#### リトライ対象
+- HTTP 429, 5xx、ETIMEDOUT、ECONNRESET 等の一時障害。
+
+#### リトライ戦略（初期値）
+- 最大試行: 2（初回 + 再試行1回）
+- バックオフ: 1.5s（指数 1.0s→2.0s でも可）
+
+#### フォールバック応答（日本語）
+- 「現在AI応答の生成で問題が発生しました。しばらくしてから再度お試しください。必要であれば、要件や前提条件をもう一度共有してください。」
+- ユーザー向けには詳細原因を出さない。ログ/監視でエラー種別・リトライ回数は記録。
+
+レビュー決定事項:
+- [ ] 試行回数・待機時間
+- [ ] フォールバック文面
+
+---
+
+## 5) キャッシュ方針
+
+- 会話キャッシュ: 現状通り（セッション単位の履歴キャッシュ）。
+- 応答キャッシュ: Phase 1 は無効（個別性が高い）。
+  - 将来キーデザイン: hash(sessionId + 正規化メッセージ + 抜粋コンテキスト)。
+  - TTL: 60秒〜5分。機能フラグ AI_FEATURE_CHAT_CACHE で切替。
+
+レビュー決定事項:
+- [ ] Phase 1 の無効化に合意
+- [ ] 将来の TTL・キー設計の方向性
+
+---
+
+## 6) セキュリティ/プライバシー/監査
+
+- PII最小化: コンテキストに不要な個人情報は送らない。会話本文そのままの再掲は避ける。
+- ログ/監査: プロンプト本文の保存は避け、ハッシュまたは短い要約のみ。エラー詳細は内部ログに限定。
+- フィーチャーフラグ: AIFeatureFlagGuard で機能切替を継続。
+- OPENAI_API_KEY 未設定時は実行せず明示エラー（OpenAIService 実装準拠）。
+
+レビュー決定事項:
+- [ ] 監査ログに残す/残さない情報の確定
+
+---
+
+## 7) 実行パラメータ（初期値・環境変数）
+
+- OPENAI_MODEL: 既定（gpt-4-turbo-preview など環境設定）。
+- OPENAI_TEMPERATURE: 0.3（安定化）。
+- OPENAI_MAX_TOKENS: 1200。
+- 履歴件数 N: 12。
+- リトライ: 1回（合計2試行）。バックオフ: 1.5s。
+- コスト: Phase 1 は 0（または total_tokens×単価係数）。
+
+レビュー決定事項:
+- [ ] 上記初期値の承認/調整
+
+---
+
+## 8) API/契約（互換性）
+
+- 変更なし。ProcessUserMessageUseCase のレスポンススキーマは維持。
+  - aiResponse.confidence の固定値撤廃により undefined になり得るが DTO は optional のため互換。
+  - usage は tokens を実値化（cost は 0 でも可）。
+
+---
+
+## 9) テスト戦略
+
+- ユニット（AIConversationService）
+  - OpenAIService をモック。正常/429/503/timeout/フォールバックを網羅。
+  - 履歴ウィンドウ N のトリミングを検証。
+- ユースケース（ProcessUserMessageUseCase）
+  - usage の tokens 実値反映の検証（cost は 0 または算出）。
+  - リトライ発火/フォールバック経路。
+- E2E
+  - 送信→応答→会話保存→WebSocket通知の一連。OpenAIService はスタブで再現。
+- ゴールデンテスト（軽量）
+  - システムプロンプト変更が破壊的でないことを確認（厳密な文面一致は避ける）。
+
+---
+
+## 10) 監視・運用
+
+- メトリクス
+  - ai_requests_total, ai_tokens_used, ai_errors_total, ai_cost_usd（cost導入後）。
+- ダッシュボード
+  - リトライ率、フォールバック率、平均応答トークン、P95 レイテンシ。
+- アラート
+  - 連続エラー率 > X%、429 多発、cost 急騰（導入後）。
+
+---
+
+## 11) 実装影響とロールアウト
+
+- 影響コード
+  - AIConversationService.processMessage（モック→OpenAI 呼び出し）。
+  - ProcessUserMessageUseCase（usage の実値反映、固定値削除）。
+  - 設定/環境変数（OPENAI_*）。
+- ロールアウト
+  - ステージングでメトリクス監視 → フィーチャーフラグで徐々に有効化。
+  - 問題時は即時フラグ無効でモックに戻せるよう分岐を残す（短期）。
+
+---
+
+## 12) 検収基準（Acceptance Criteria）
+
+- モック定型文が出ず、日本語で意味のある応答が返る。
+- 履歴 N の変更でエラーなく動作、トークン上限制御が機能。
+- 障害時に日本語フォールバックが返る。リトライ/ログが記録される。
+- usage.total_tokens が 0 以外の実値を記録（cost は方針に従う）。
+- API レスポンス互換でフロントのUI崩れなし。
+
+---
+
+## 13) オープン事項（要レビュー）
+
+1) System Prompt 最終文面の承認。
+2) 履歴件数 N=12 と max_tokens=1200 の承認/調整。
+3) cost 算出の導入時期と単価定義（Phase1 で 0 維持 or 実値）。
+4) フォールバック文面の確定。
+5) 応答キャッシュ（Phase1 は無効のまま）可否・将来方針。
+
+---
+
+## 付録A: コード対応表
+
+- 応答生成: domain/ai-agent/services/ai-conversation.service.ts
+- OpenAI 呼び出し: infrastructure/ai/openai.service.ts
+- メッセージ処理: application/usecases/ai-agent/process-user-message.usecase.ts
+- DTO/Mapper: application/dto/ai-agent/*.ts, domain/ai-agent/mappers/*.ts
+- 監視/監査: infrastructure/monitoring/*, interfaces/controllers/ai-agent.controller.ts（Audit）
+
+---
+
+## 反復計画
+- v1.0（本書）レビュー → 承認事項を反映して v1.1 を確定。
+- v1.1 確定後に実装ブランチ着手（小PR分割）。
+

--- a/docs/ver1.2/ai_agent_minimal_design_spec.md
+++ b/docs/ver1.2/ai_agent_minimal_design_spec.md
@@ -1,0 +1,383 @@
+## AIエージェント チャット応答 OpenAI 切替 ― 詳細設計 v1.1 (Review Draft)
+
+作成日: 2025-09-04
+状態: v1.1 Review Draft
+
+---
+
+### 目的・前提
+- 本設計は「要件（ai_agent_minimal_design_addendum.md）」を満たすための、実装に必要な定義情報を提示する。
+- 設計の粒度: クラス/メソッド/インターフェイス/Enum/必要に応じたテーブル定義、シーケンス図。
+- サンプルコードは含めない（定義系のみ）。
+
+### スコープ（Phase 1）
+- AIConversationService.processMessage を OpenAIService.generateResponse 経由に切替。
+- PromptBuilder/HistoryAssembler/LLMOutputParser の導入。
+- 返却DTOの互換性維持（aiResponse.content は人間可読、日本語）。
+- 構造化JSON（ai_chat_process_template.v1）を応答末尾に添付（要件準拠）。
+- usage.tokens の実値反映。cost は導入時期選択（未導入でも可）。
+
+非スコープ
+- テンプレ自動作成の実施（本Phaseは下準備まで）。
+
+---
+
+## 1. レイヤー別設計
+
+### 1.1 Interfaces（Controller / WebSocket）
+- 既存 AIAgentController のエンドポイントは維持。
+  - POST /ai-agent/sessions/:sessionId/messages
+  - 役割: 入力検証→UseCase呼出→レスポンス返却（構造化JSONは aiResponse.content 末尾のコードフェンス内に含まれる）
+- SocketGateway: 変更なし。
+
+### 1.2 Application（UseCases/Services）
+- UseCase: ProcessUserMessageUseCase
+  - 入力: { sessionId: string; userId: string; message: string }
+  - 出力: { aiResponse: AIResponseDto; conversation: ConversationMessageDto[]; usage: UsageDto }
+  - 呼出: PromptBuilder.buildSystemPrompt(context), HistoryAssembler.build(session, N), AIConversationService.processMessage(...), LLMOutputParser.extractTemplateJson(aiResponse.content)
+  - 副作用: 会話保存、レート制限記録、モニタリング、（必要に応じて）構造化JSONの検証結果をログ。
+
+- Service: PromptBuilder
+  - 役割: System Prompt文字列の生成（要件に定義の方針）。
+  - 入力: SessionContextDto（industry, processType, goal, region, compliance, additionalContext など）
+  - 出力: string（system用プロンプト）
+
+- Service: HistoryAssembler
+  - 役割: 履歴 N 件の切り出しと OpenAI 形式メッセージ配列の生成。
+  - 入力: InterviewSession + N
+  - 出力: ChatMessage[]（systemは別途）
+
+- Service: LLMOutputParser
+  - 役割: aiResponse.content の末尾から ```json フェンス内の厳密JSONを抽出、スキーマ検証、Dtoへのマッピング補助。
+  - 入力: aiResponse.content（string）
+  - 出力: TemplateDraftParseResult（成功: AiChatProcessTemplateJson, 失敗: エラー情報）
+
+- Mapper: TemplateDraftMapper
+  - 役割: AiChatProcessTemplateJson → CreateProcessTemplateDto への変換。
+  - 入力: AiChatProcessTemplateJson
+  - 出力: CreateProcessTemplateDto
+
+### 1.3 Domain
+- Service: AIConversationService（既存の差し替え）
+  - 役割: PromptBuilder/HistoryAssembler が作るメッセージを使って OpenAIService から応答を取得。
+  - 入力: ProcessMessageInput
+  - 出力: ProcessMessageOutput（content は日本語文章＋末尾にJSONフェンス）
+
+- Entities: InterviewSession / ConversationMessage（既存）
+  - 変更なし。
+
+### 1.4 Infrastructure
+- OpenAIService（既存）
+  - generateResponse にて usage を必ず返却。rawText も返せるよう型定義を明確化。
+- Monitoring/RateLimit（既存）
+  - tokens 実値を記録。cost は0でも可。
+
+### 1.5 Persistence（DB）
+- Phase 1: テーブル変更なし。
+  - 構造化JSONはレスポンスで返し、必要に応じてフロントまたは後続APIでテンプレ作成に利用。
+- 将来案: ai_chat_outputs テーブル（監査や再処理用）
+  - id, session_id, schema, json_payload(jsonb), created_at など（本Phaseは設計のみ言及）。
+
+---
+
+## 1.x 具体的設計決定（補強）
+
+### A) dependsOn（seq→ID解決）
+
+- 入力制約
+  - seq は 1..N の連番（欠番/重複不可）
+  - dependsOn は seq を参照し、将来参照（自分より大きい seq）禁止
+- 正規化手順
+  1. DTO を seq 昇順に検証
+  2. Tx 開始、各ステップを挿入（depends_on_json は一旦 []）
+  3. seq→id マップを確定
+  4. 各ステップの dependsOn(seq[]) を id[] に変換して更新
+  5. 循環検査（DAG）。不合格は rollback
+- 例外/応答: 欠番/重複/将来参照/循環は 400（検証失敗）
+- 監査: エラー分類を記録（本文保存なし）
+
+### B) LLM 構造化JSON 抽出・検証
+
+- 抽出優先: 「最後の」フェンス。言語ラベル json を最優先
+- フェンスがない場合: 最後のコードブロックで先頭が { 末尾が } の場合のみ候補
+- フェンスサイズ上限: 32KB
+- 検証
+  - 厳密 JSON（コメント/末尾カンマ不可）
+  - schema === ai_chat_process_template.v1
+  - stepTemplates: 必須フィールドと値域、seq 連番、seq=1 の basis は 'goal'
+- エラー分類: MissingFence / NonJsonFence / JsonParseError / SchemaMismatch / ValidationFailed
+- フォールバック: JSON が取り出せない場合でも会話応答は返す（JSON無し）
+- 監査: schemaId とエラー分類のみ記録
+
+### C) トークン予算と履歴トリミング
+
+- 定数
+  - responseMaxTokens = OPENAI_MAX_TOKENS（例: 1200）
+  - safetyMarginTokens = 200
+- 予算: contextBudget = modelContextLimit - (responseMaxTokens + safetyMarginTokens) - systemTokens
+- 見積り: tokens≈ceil(utf8_bytes/4)
+- 手順
+  1. 最新から逆順に積み上げ、予算内になるまで採用
+  2. 最低限、直近の user/assistant ペアは含める
+
+### D) フォールバック仕様
+
+- トリガ: Timeout/429/5xx/ネットワーク例外でリトライ枯渇
+- 応答: content=固定日本語、usage.tokens=0、costUsd=0または未設定、JSON無し
+- 監査: errorType, retryCount, duration（本文保存なし）
+
+### E) 監査ハッシュ
+
+- 正規化: role:content\n を連結、連続空白1つへ圧縮、先頭1000文字へ切詰め
+- ハッシュ: SHA-256( AI_AUDIT_SALT + normalized )
+- SALT 未設定: ハッシュ生成は無効化
+
+### F) フィーチャーフラグ/DI 切替
+
+- Token: AIConversationResponder
+- 実装: MockResponder / OpenAIResponder
+- Factory: 環境 AI_AGENT_MODE = 'mock'|'openai' でバインド
+
+### G) 言語ポリシー（Phase1）
+
+- 常に日本語。将来 languagePolicy を導入可能とする
+
+---
+
+## 2. インターフェイス/DTO/Enum 定義
+
+> 注意: 以下は定義情報であり、実装は含みません。
+
+### 2.1 OpenAI 連携
+
+```ts
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface OpenAIResponseUsage {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number; // 必須
+}
+
+export interface OpenAIResponse {
+  content: string; // アシスタントのテキスト（人間可読＋末尾にjsonフェンス）
+  usage: OpenAIResponseUsage;
+  raw?: unknown; // ベンダー固有情報（監視/デバッグ用）
+}
+```
+
+### 2.2 Prompt/History
+
+```ts
+export interface SessionContextDto {
+  industry?: string;
+  processType?: string;
+  goal?: string;
+  region?: string;
+  compliance?: string;
+  additionalContext?: string;
+}
+
+export interface HistoryAssemblerOptions {
+  windowSize: number; // 例: 12
+  maxTokensBudget?: number; // 省略可
+}
+```
+
+### 2.3 会話処理（UseCase↔Domain）
+
+```ts
+export interface ProcessMessageInput {
+  sessionId: string;
+  userId: string;
+  message: string;
+  context?: SessionContextDto;
+  historyWindow?: number; // 例: 12
+}
+
+export interface ProcessMessageOutput {
+  content: string; // 日本語の人間可読回答＋末尾にJSON
+  usage: { tokens: number; costUsd?: number };
+}
+```
+
+### 2.4 構造化JSON（要件準拠）
+
+```ts
+export enum AiChatSchemaId {
+  ProcessTemplateV1 = 'ai_chat_process_template.v1',
+}
+
+export interface StepTemplateDraft {
+  seq: number; // 1..N 連番
+  name: string;
+  basis: 'goal' | 'prev';
+  offsetDays: number; // -365..365 の整数
+  requiredArtifacts?: Array<{ kind: string; description?: string }>;
+  dependsOn?: number[]; // seq 参照
+}
+
+export interface AiChatProcessTemplateJson {
+  schema: AiChatSchemaId.ProcessTemplateV1;
+  answer: string; // 日本語要約
+  missing_information?: string[];
+  process_template_draft?: {
+    name?: string;
+    stepTemplates: StepTemplateDraft[];
+  };
+}
+
+export interface TemplateDraftParseResult {
+  ok: boolean;
+  schema?: AiChatSchemaId;
+  data?: AiChatProcessTemplateJson;
+  errors?: string[]; // 検証エラー一覧
+}
+```
+
+### 2.5 CreateProcessTemplate 連携（既存DTOへの写像）
+
+```ts
+export interface CreateStepTemplateDto {
+  seq: number;
+  name: string;
+  basis: 'goal' | 'prev';
+  offsetDays: number;
+  requiredArtifacts?: Array<{ kind: string; description?: string }>;
+  dependsOn?: number[];
+}
+
+export interface CreateProcessTemplateDto {
+  name: string;
+  stepTemplates: CreateStepTemplateDto[];
+}
+```
+
+### 2.6 エラー/例外
+
+```ts
+export enum AIConversationErrorCode {
+  OpenAIUnavailable = 'OpenAIUnavailable',
+  RateLimited = 'RateLimited',
+  Timeout = 'Timeout',
+  InvalidStructuredJson = 'InvalidStructuredJson',
+}
+```
+
+---
+
+## 3. クラス定義（概要）
+
+### 3.1 PromptBuilder
+- 責務: 要件文面に準拠した System Prompt を生成。
+- メソッド
+  - buildSystemPrompt(context: SessionContextDto): string
+
+### 3.2 HistoryAssembler
+- 責務: セッションから直近 N 件の履歴を抽出し、ChatMessage[] を生成。
+- メソッド
+  - build(sessionId: string, options: HistoryAssemblerOptions): Promise<ChatMessage[]> // user/assistantのみ
+
+### 3.3 AIConversationService（差し替え）
+
+- 責務: System + History + User を OpenAIService へ渡し、応答を受領。
+- メソッド
+  - processMessage(input: ProcessMessageInput): Promise<ProcessMessageOutput>
+  - 内部で OpenAIService.generateResponse(messages, {model, temperature, maxTokens, retryPolicy}) を使用
+
+### 3.4 LLMOutputParser
+
+- 責務: aiResponse.content 末尾の JSON フェンスを抽出・検証。
+- メソッド
+  - extractTemplateJson(content: string): TemplateDraftParseResult
+
+### 3.5 TemplateDraftMapper
+
+- 責務: AiChatProcessTemplateJson → CreateProcessTemplateDto への写像（必要時）。
+- メソッド
+  - toCreateDto(json: AiChatProcessTemplateJson): CreateProcessTemplateDto
+
+### 3.6 OpenAIService（型の明確化）
+
+- メソッド
+  - generateResponse(messages: ChatMessage[], options?: { model?: string; temperature?: number; maxTokens?: number }): Promise<OpenAIResponse>
+
+---
+
+## 4. 振る舞い/フロー（シーケンス図）
+
+### 4.1 チャット応答生成（構造化JSON付）
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant UI as Web UI
+  participant API as AIAgentController
+  participant UC as ProcessUserMessageUseCase
+  participant PB as PromptBuilder
+  participant HA as HistoryAssembler
+  participant SVC as AIConversationService
+  participant OAI as OpenAIService
+  participant PAR as LLMOutputParser
+
+  UI->>API: POST /ai-agent/sessions/:id/messages
+  API->>UC: execute(sessionId, userId, message)
+  UC->>PB: buildSystemPrompt(context)
+  PB-->>UC: systemPrompt
+  UC->>HA: build(sessionId, {windowSize:N})
+  HA-->>UC: ChatMessage[]
+  UC->>SVC: processMessage({prompt, history, message})
+  SVC->>OAI: generateResponse(messages, opts)
+  OAI-->>SVC: OpenAIResponse(content + usage)
+  SVC-->>UC: ProcessMessageOutput
+  UC->>PAR: extractTemplateJson(content)
+  PAR-->>UC: TemplateDraftParseResult(検証結果)
+  UC-->>API: aiResponse + usage（JSONはcontent末尾）
+  API-->>UI: 200 OK
+```
+
+### 4.2 テンプレ作成（将来・参照）
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant UI as Web UI
+  participant API as ProcessTemplateController
+  participant UC as CreateProcessTemplateUseCase
+
+  UI->>API: POST /process-templates (body=CreateProcessTemplateDto)
+  API->>UC: execute(dto)
+  UC-->>API: templateId
+  API-->>UI: 201 Created
+```
+
+---
+
+## 5. 設定・パラメータ（初期値）
+
+- モデル: OPENAI_MODEL（現行の既定）
+- temperature: 0.3
+- maxTokens: 1200
+- 履歴ウィンドウ N: 12
+- リトライ: 最大1回（合計2試行）、バックオフ1.5s
+
+---
+
+## 6. 受け入れ条件（設計の充足判定）
+
+- すべての定義（クラス/メソッド/インターフェイス/Enum）が本書に記載。
+- 既存API契約を維持しつつ、aiResponse.content 末尾に厳密JSONを付与できる。
+- LLMOutputParser がスキーマ検証可能で、CreateProcessTemplateDto への写像ルールが明確。
+- DB 変更なしで Phase1 が実装可能。
+
+---
+
+## 7. オープン事項（要レビュー）
+
+1) PromptBuilder の最終文面（addendumのsystem prompt）
+2) Parserの厳格度（欠番/循環の扱い・警告で許容するか、エラーで拒否するか）
+3) cost 実装の有効化タイミング
+4) 監査ログの粒度（スキーマID/ハッシュのみ保存）

--- a/docs/ver1.2/ai_agent_unit_test_plan_v1.1.md
+++ b/docs/ver1.2/ai_agent_unit_test_plan_v1.1.md
@@ -1,0 +1,185 @@
+## AIエージェント チャット応答 OpenAI 切替 — ユニットテスト計画 v1.1 (Draft)
+
+作成日: 2025-09-06
+対象ブランチ: feature/ai-agent-v1.2-openai-chat
+設計準拠: docs/ver1.2/ai_agent_minimal_design_spec.md (v1.1)
+要件準拠: docs/ver1.2/ai_agent_minimal_design_addendum.md (v1.0)
+
+---
+
+### 1. 目的と方針
+- 目的: フェーズ1(PR1〜PR5)の実装に対し、単体レベルで仕様準拠・回帰・エラー耐性を確認する
+- 方針:
+  - 外部依存や重い層は徹底的にモック/スタブ化
+  - 正常/境界/異常(フォールバック含む)の網羅を優先、カバレッジは結果として70%目安
+  - API契約は変更しない（テストは副作用・呼び出し・戻り値を検証）
+
+---
+
+### 2. テスト対象(新規/変更点)
+- application/services/ai-agent/
+  - prompt-builder.service.ts
+  - history-assembler.service.ts
+  - llm-output-parser.service.ts
+  - openai-responder.service.ts
+- application/usecases/ai-agent/process-user-message.usecase.ts
+- application/usecases/ai-agent/ai-agent.module.ts（DI切替）
+- application/interfaces/ai-agent/types.ts（構造化JSON定義類）
+- application/interfaces/ai-agent/ai-conversation-responder.interface.ts（tokenCount追加）
+- infrastructure/ai/openai.service.ts（overrideSystemPrompt追加）
+- infrastructure/monitoring/ai-audit.service.ts（監査ハッシュ）
+- infrastructure/monitoring/ai-monitoring.service.ts（ログ呼び出し対象）
+
+---
+
+### 3. 単体テスト戦略
+- 正常系/異常系/境界を最小ユニットで検証
+- 呼び出し回数・引数・戻り値・例外伝播・フォールバックを確認
+- 監査・メトリクスは「呼び出しの発生」を確認、数値妥当性は計測層の責務
+
+---
+
+### 4. コンポーネント別テストケース
+
+#### 4.1 PromptBuilder
+- 目的: SessionContextDtoから日本語System Promptを生成
+- モック: なし
+- ケース:
+  - 空コンテキストでも固定文言（日本語/構造化/JSON1個）が含まれる
+  - industry/processType/goal/region+compliance/additionalContext の埋め込み
+  - complianceが配列/文字列/未定義での表記差
+  - 出力要件(末尾JSONフェンス)の文言が含まれる
+
+#### 4.2 HistoryAssembler
+- 目的: 直近N件の user/assistant を抽出し、systemPromptを先頭注入、予算でトリム
+- モック: InterviewSessionRepository.findById（フェイクセッション）
+- ケース:
+  - user/assistantのみ抽出（systemは履歴からは除外）
+  - windowSize=Nのスライス（古→新でN件）
+  - systemPrompt指定時は先頭に挿入
+  - 予算(utf8_bytes/4)超過時に先頭から削除（systemは極力保持）
+  - 最低限、直近の user/assistant ペアを保持（長文で極端に削れても最後は2件）
+  - セッション無し/会話無し→空配列
+  - getRole()/toString()経由のロール取得の堅牢性
+
+#### 4.3 LLMOutputParser
+- 目的: 最終フェンスから厳密JSON抽出/検証/分類
+- モック: なし
+- ケース(エラー分類網羅):
+  - MissingFence: フェンス無し
+  - NonJsonFence: フェンスあるが {..} でない
+  - FenceTooLarge: 32KB超
+  - JsonParseError: JSON.parse例外（末尾カンマ等）
+  - SchemaMismatch: schema != ai_chat_process_template.v1
+  - ValidationFailed: 連番欠落(seq 1,3)、先頭basis!=goal、dependsOn範囲外/未来参照
+  - 正常系: 空stepTemplates/正常stepTemplates（連番・先頭goal・依存OK）
+  - 複数フェンス: 最後のフェンス優先、jsonラベル優先
+
+- 追加テスト（曖昧表記/境界）:
+  - フェンス言語ラベルのバリエーション: ```JSON``` / ```jsonc``` / ```json```（スペース無しのみ許容）
+  - 改行コード CRLF 対応: ```json\r\n...``` のケース
+  - フェンス優先順位: 非jsonフェンスが最後、途中に ```json``` がある場合は最後の json フェンスを拾えること
+  - サイズ境界: 32KB ちょうどは許可、32KB+1 は拒否
+  - JSON 厳密性の追加負例: キー重複・コメント混入
+
+#### 4.4 OpenAIService（小回帰）
+
+- 目的: overrideSystemPromptの優先適用
+- モック: 内部OpenAIクライアント（chat.completions.create）
+- ケース:
+  - override指定時は buildSystemPrompt() 不使用で system=override がmessages[0]
+  - override無し時は従来の buildSystemPrompt(context)
+  - previousMessages がmessagesに順序保持で反映
+
+#### 4.5 OpenAIResponder
+
+- 目的: Prompt/Historyを用いてOpenAIService.generateResponse呼び出し（override付）、tokenCount反映
+- モック: PromptBuilder, HistoryAssembler, OpenAIService, AIConfigService
+- ケース:
+  - 正常: content/metadata.tokensUsed を取得し tokenCount に反映
+  - context.previousMessages に履歴が渡る
+  - 第3引数 overrideSystemPrompt が使用される
+  - 例外時: 例外を上位へ伝播（フォールバックはUseCase側の責務）
+
+#### 4.6 ProcessUserMessageUseCase
+
+- 目的: 入力検証→レート制限→セッション→会話更新→非同期→キャッシュ→usageログ→通知→進捗
+- モック: Repository/RateLimit/Monitoring/Queue/Socket/Cache/Analysis/Responder
+- 正常:
+  - responder.tokenCount が aiResponse.tokenCount に反映、logUsage に記録
+  - 会話に user/assistant が追加、updateConversation が呼ばれる
+  - ジョブ(REQUIREMENT_ANALYSIS)投入、WebSocket通知
+- 異常/フォールバック:
+  - 入力不備・長文>2000 で DomainException
+  - レート制限、セッション未発見/別ユーザー/非ACTIVE/期限切れで DomainException
+  - responder 例外→ handleOpenAIError のリトライ後にフォールバック
+  - フォールバック: 日本語固定文、suggestedQuestions空、confidence=0、tokenCount=0、estimatedCost=0、error=true
+- JSON解析/監査:
+  - parser成功→ monitoring.logAIRequest('structured_json_ok', tokens, cost)
+  - 失敗→ monitoring.logAIError('parse_structured_json', Error([...]))
+  - 監査ハッシュ: SALTあり→非null（ログ呼び出し発生）、SALTなし→null（未発生）
+
+#### 4.7 AIAgentModule（DI切替）
+
+- 目的: AI_AGENT_MODE=mock|openai でトークン解決先が切替
+- モック: AIConfigService, AIConversationService, OpenAIResponder
+- ケース:
+  - mock→ AIConversationService 注入
+  - openai→ OpenAIResponder 注入
+
+#### 4.8 AIAuditService
+
+- 目的: 正規化+SHA-256(SALT+normalized)
+- モック: ConfigService（SALT）
+- ケース:
+  - SALTあり→hex文字列
+  - SALTなし→null
+  - 正規化（空白圧縮/1000文字切詰）の安定性
+
+#### 4.9 AIMonitoringService（軽）
+
+- 目的: ログAPI呼び出しの計測呼び出し
+- モック: MetricsService
+- ケース:
+  - logAIRequest→ ai_requests_total 増分、ai_tokens_used/ai_cost_usd 記録
+  - logAIError→ ai_errors_total 増分
+
+---
+
+### 5. フィクスチャ/テストデータ
+- 会話サンプル: user/assistant 交互、長文で予算超過を誘発、不正ロール(toString小文字化)含む
+- LLM出力サンプル: 正常JSON、末尾カンマ、複数フェンス(json/非json混在)、32KB超ブロック
+
+---
+
+### 6. モック/スパイ方針
+- OpenAIService: jest.fn().mockResolvedValue({ content: '...', metadata: { tokensUsed: 123 } })
+- InterviewSessionRepository: findById→簡易セッションスタブ（getConversation/addMessage動作）
+- Monitoring/Queue/Socket/Cache/Analysis/RateLimit: 呼び出しと引数検証中心
+- Env: process.env.AI_AGENT_MODE を一時変更（afterEachで復元）
+
+---
+
+### 7. 実施順序
+1) LLMOutputParser
+2) PromptBuilder / HistoryAssembler
+3) OpenAIService（overrideの小回帰）
+4) OpenAIResponder
+5) AIAuditService
+6) ProcessUserMessageUseCase
+7) AIAgentModule（DI切替）
+
+---
+
+### 8. 成功基準
+- 各コンポーネントの正常/異常/境界ケースが再現可能
+- tokens実値・日本語フォールバック・JSON検証・監査ハッシュ・DI切替が仕様通りに動作
+- カバレッジは結果として statements/branches 70%程度（目標）
+
+---
+
+### 9. リスクと注意
+- Entity API依存の箇所はDTO化や軽量スタブで代替し、ユニットの独立性を維持
+- 正規表現抽出は誤検出の余地→負例を厚めに
+- OpenAIService署名変更の回帰→既存呼び出し箇所のユニットも軽くカバー（分析/テンプレ生成は影響最小の想定）
+


### PR DESCRIPTION
## 概要
- v1.1 (#54): モック脱却しOpenAI接続へ。厳密JSON（ai_chat_process_template.v1）出力・検証、フォールバック、最小監査/メトリクスを導入。
- 会話保存・要件抽出ジョブ投入・WebSocket通知の整備。
- v1.2 (#55): Draft→Finalize→正式テンプレ登録の接続設計ドキュメントを追加。

## 変更点（主なもの）
- ai-agent
  - PromptBuilder強化、OpenAIResponder/Service配線
  - LLMOutputParser（厳密JSON抽出/検証）+ ユニットテスト
  - ProcessUserMessageUseCase: OpenAI応答、会話履歴保存、背景ジョブ投入
  - AIAgentController: エンドポイントの最小整備
- infra
  - WebSocket通知の土台整備
- docs
  - docs/ver1.2/ai_agent_draft_to_template_integration_design.md（v1.2設計）

## 確認事項
- devでのメトリクス警告（'ai_tokens_used' など）は未登録によるもので実装上は非ブロッキング
- api/.env.test のOpenAIキーはsecret scanning回避のため空に修正済み

## テスト
- llm-output-parser.service.spec.ts 追加
- 既存ユニット/統合が通ることを確認予定（CI）

## 次フェーズ（別Issue #55）
- Draft保存（会話時）+ Finalizeで正式テンプレ登録（CreateProcessTemplateUseCase）
- 履歴 markAsUsed、Feature Flag、名称競合ポリシーの詰め

よろしくお願いします。

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author