### PR TITLE
PR1+PR2+PR3 – TemplateDraftMapper 実装とDraft保存・Finalize（Feature Flag制御）

### DIFF
--- a/api/src/application/services/ai-agent/template-draft-mapper.service.spec.ts
+++ b/api/src/application/services/ai-agent/template-draft-mapper.service.spec.ts
@@ -1,0 +1,132 @@
+import { TemplateDraftMapper } from './template-draft-mapper.service';
+import { AiChatProcessTemplateJson, AiChatSchemaId } from '../../interfaces/ai-agent/types';
+
+function makeAiChat(overrides?: Partial<AiChatProcessTemplateJson>): AiChatProcessTemplateJson {
+  return {
+    schema: AiChatSchemaId.ProcessTemplateV1,
+    answer: 'テスト回答',
+    process_template_draft: {
+      name: 'サンプルプロセス',
+      stepTemplates: [
+        { seq: 1, name: '要件整理', basis: 'goal', offsetDays: 0 },
+        { seq: 2, name: '設計', basis: 'prev', offsetDays: 3, dependsOn: [1] },
+        { seq: 3, name: '実装', basis: 'prev', offsetDays: 5, dependsOn: [1, 2] },
+      ],
+    },
+    ...overrides,
+  } as AiChatProcessTemplateJson;
+}
+
+describe('TemplateDraftMapper', () => {
+  let mapper: TemplateDraftMapper;
+
+  beforeEach(() => {
+    mapper = new TemplateDraftMapper();
+  });
+
+  describe('toSessionDraft', () => {
+    it('maps ai_chat to GeneratedTemplate with defaults', () => {
+      const ai = makeAiChat();
+      const draft = mapper.toSessionDraft(ai);
+
+      expect(draft.name).toBe('サンプルプロセス');
+      expect(draft.steps.length).toBe(3);
+      expect(draft.steps[0]).toEqual({ name: '要件整理', description: '', duration: 0, dependencies: [] });
+      expect(draft.steps[1]).toEqual({ name: '設計', description: '', duration: 3, dependencies: [1] });
+      expect(draft.steps[2]).toEqual({ name: '実装', description: '', duration: 5, dependencies: [1, 2] });
+      expect(draft.metadata.confidence).toBeGreaterThan(0);
+      expect(Array.isArray(draft.metadata.sources)).toBe(true);
+      expect(typeof draft.metadata.generatedAt).toBe('string');
+    });
+
+    it('uses fallback name and empty steps when draft missing', () => {
+      const ai = makeAiChat({ process_template_draft: undefined } as any);
+      const draft = mapper.toSessionDraft(ai);
+      expect(draft.name.startsWith('AI Draft (')).toBe(true);
+      expect(draft.steps).toEqual([]);
+    });
+
+    it('logs WARN and defaults duration when offsetDays missing or non-numeric', () => {
+      const ai = makeAiChat({
+        process_template_draft: {
+          name: 'X',
+          stepTemplates: [
+            { seq: 1, name: 'A', basis: 'goal', offsetDays: NaN as any },
+            { seq: 2, name: 'B', basis: 'prev', offsetDays: undefined as any },
+          ],
+        },
+      } as any);
+      const draft = mapper.toSessionDraft(ai);
+      expect(draft.steps[0].duration).toBe(0);
+      expect(draft.steps[1].duration).toBe(0);
+    });
+  });
+
+  describe('toCreateDtoFromAiChat', () => {
+    it('maps ai_chat to CreateProcessTemplateDto and clamps offsetDays', () => {
+      const ai = makeAiChat({
+        process_template_draft: {
+          name: 'P',
+          stepTemplates: [
+            { seq: 1, name: 'S1', basis: 'goal', offsetDays: -999 },
+            { seq: 2, name: 'S2', basis: 'prev', offsetDays: 999, dependsOn: [1] },
+          ],
+        },
+      } as any);
+
+      const dto = mapper.toCreateDtoFromAiChat(ai);
+      expect(dto.name).toBe('P');
+      expect(dto.stepTemplates.length).toBe(2);
+      expect(dto.stepTemplates[0]).toEqual({ seq: 1, name: 'S1', basis: 'goal', offsetDays: -365, requiredArtifacts: [], dependsOn: [] });
+      expect(dto.stepTemplates[1]).toEqual({ seq: 2, name: 'S2', basis: 'prev', offsetDays: 365, requiredArtifacts: [], dependsOn: [1] });
+    });
+
+    it('fills defaults when fields are missing', () => {
+      const ai = makeAiChat({
+        process_template_draft: {
+          name: '',
+          stepTemplates: [
+            { seq: 1, name: '', basis: 'goal', offsetDays: 0 },
+            { name: '', basis: 'prev', offsetDays: 2 } as any,
+          ],
+        },
+      } as any);
+
+      const dto = mapper.toCreateDtoFromAiChat(ai);
+      expect(dto.name.startsWith('AI Draft (')).toBe(true);
+      expect(dto.stepTemplates[0].name).toBe('Step 1');
+      expect(dto.stepTemplates[1].seq).toBe(2);
+      expect(dto.stepTemplates[1].name).toBe('Step 2');
+      expect(dto.stepTemplates[0].requiredArtifacts).toEqual([]);
+    });
+  });
+
+  describe('toCreateDtoFromDraft', () => {
+    it('maps GeneratedTemplate to CreateProcessTemplateDto with basis and dependsOn', () => {
+      const ai = makeAiChat();
+      const draft = mapper.toSessionDraft(ai);
+      const dto = mapper.toCreateDtoFromDraft(draft);
+
+      expect(dto.name).toBe(draft.name);
+      expect(dto.stepTemplates[0]).toEqual({ seq: 1, name: '要件整理', basis: 'goal', offsetDays: 0, requiredArtifacts: [], dependsOn: [] });
+      expect(dto.stepTemplates[1]).toEqual({ seq: 2, name: '設計', basis: 'prev', offsetDays: 3, requiredArtifacts: [], dependsOn: [1] });
+      expect(dto.stepTemplates[2]).toEqual({ seq: 3, name: '実装', basis: 'prev', offsetDays: 5, requiredArtifacts: [], dependsOn: [1, 2] });
+    });
+
+    it('clamps duration (mapped to offsetDays) when out of range', () => {
+      const draft = {
+        name: 'D',
+        steps: [
+          { name: 'A', description: '', duration: -999, dependencies: [] },
+          { name: 'B', description: '', duration: 999, dependencies: [1] },
+        ],
+        metadata: { generatedAt: new Date().toISOString(), confidence: 0.8, sources: [] },
+      };
+
+      const dto = mapper.toCreateDtoFromDraft(draft as any);
+      expect(dto.stepTemplates[0].offsetDays).toBe(-365);
+      expect(dto.stepTemplates[1].offsetDays).toBe(365);
+    });
+  });
+});
+

--- a/api/src/application/services/ai-agent/template-draft-mapper.service.ts
+++ b/api/src/application/services/ai-agent/template-draft-mapper.service.ts
@@ -1,10 +1,150 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { AiChatProcessTemplateJson } from '../../interfaces/ai-agent/types';
+import { GeneratedTemplate } from '../../../domain/ai-agent/entities/interview-session.entity';
+import { CreateProcessTemplateDto } from '../../dto/process-template/create-process-template.dto';
 
 @Injectable()
 export class TemplateDraftMapper {
-  toCreateDto(json: any): any {
-    // Stub implementation per PR1 (no logic yet)
-    return null;
+  private readonly logger = new Logger(TemplateDraftMapper.name);
+
+  // PR1: ai_chat -> Session Draft
+  toSessionDraft(aiChat: AiChatProcessTemplateJson): GeneratedTemplate {
+    const draft = aiChat?.process_template_draft;
+
+    const name = (draft?.name && draft.name.trim().length > 0)
+      ? draft.name.trim()
+      : this.fallbackName();
+
+    const steps = Array.isArray(draft?.stepTemplates)
+      ? draft!.stepTemplates.map((s, idx) => {
+          const stepName = (s.name && s.name.trim().length > 0)
+            ? s.name.trim()
+            : `Step ${s.seq ?? idx + 1}`;
+
+          const rawOffset = (s as any).offsetDays;
+          const duration = this.safeNumber(rawOffset, 0, () => {
+            this.logger.warn(`Non-numeric or missing offsetDays detected for seq=${s.seq ?? idx + 1}. Defaulting to 0.`);
+          });
+
+          const deps = Array.isArray(s.dependsOn) ? s.dependsOn.slice() : [];
+
+          return {
+            name: stepName,
+            description: '', // server-side does not synthesize description in PR1
+            duration,
+            dependencies: deps,
+          };
+        })
+      : [];
+
+    return {
+      name,
+      steps,
+      metadata: {
+        generatedAt: new Date().toISOString(),
+        confidence: 0.8,
+        sources: [],
+      },
+    };
+  }
+
+  // PR1: ai_chat -> CreateProcessTemplateDto
+  toCreateDtoFromAiChat(aiChat: AiChatProcessTemplateJson): CreateProcessTemplateDto {
+    const draft = aiChat?.process_template_draft;
+
+    const name = (draft?.name && draft.name.trim().length > 0)
+      ? draft.name.trim()
+      : this.fallbackName();
+
+    const steps = Array.isArray(draft?.stepTemplates) ? draft!.stepTemplates : [];
+
+    const stepTemplates = steps.map((s, idx) => {
+      const seq = typeof s.seq === 'number' ? s.seq : idx + 1;
+      const stepName = (s.name && s.name.trim().length > 0) ? s.name.trim() : `Step ${seq}`;
+
+      const rawOffset = (s as any).offsetDays;
+      const { value: offsetDays, clamped } = this.clampOffset(rawOffset);
+      if (clamped) {
+        this.logger.warn(`offsetDays out of range for seq=${seq}. Clamped to ${offsetDays}. (raw=${rawOffset})`);
+      }
+      if (!this.isFiniteNumber(rawOffset)) {
+        this.logger.warn(`Non-numeric or missing offsetDays detected for seq=${seq}. Defaulting to 0.`);
+      }
+
+      return {
+        seq,
+        name: stepName,
+        basis: seq === 1 ? 'goal' as const : 'prev' as const,
+        offsetDays,
+        requiredArtifacts: [],
+        dependsOn: Array.isArray(s.dependsOn) ? s.dependsOn.slice() : [],
+      };
+    });
+
+    return { name, stepTemplates };
+  }
+
+  // PR1: Draft -> CreateProcessTemplateDto
+  toCreateDtoFromDraft(draft: GeneratedTemplate): CreateProcessTemplateDto {
+    const name = (draft?.name && draft.name.trim().length > 0)
+      ? draft.name.trim()
+      : this.fallbackName();
+
+    const steps = Array.isArray(draft?.steps) ? draft.steps : [];
+
+    const stepTemplates = steps.map((s, idx) => {
+      const seq = idx + 1;
+      const stepName = (s.name && s.name.trim().length > 0) ? s.name.trim() : `Step ${seq}`;
+
+      const { value: offsetDays, clamped } = this.clampOffset((s as any).duration);
+      if (clamped) {
+        this.logger.warn(`duration (mapped to offsetDays) out of range for seq=${seq}. Clamped to ${offsetDays}. (raw=${(s as any).duration})`);
+      }
+      if (!this.isFiniteNumber((s as any).duration)) {
+        this.logger.warn(`Non-numeric or missing duration detected for seq=${seq}. Defaulting to 0.`);
+      }
+
+      return {
+        seq,
+        name: stepName,
+        basis: seq === 1 ? 'goal' as const : 'prev' as const,
+        offsetDays,
+        requiredArtifacts: [],
+        dependsOn: Array.isArray(s.dependencies) ? s.dependencies.slice() : [],
+      };
+    });
+
+    return { name, stepTemplates };
+  }
+
+  private fallbackName(): string {
+    const dt = new Date();
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    const stamp = `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())} ${pad(dt.getHours())}:${pad(dt.getMinutes())}:${pad(dt.getSeconds())}`;
+    return `AI Draft (${stamp})`;
+  }
+
+  private isFiniteNumber(v: any): v is number {
+    return typeof v === 'number' && Number.isFinite(v);
+  }
+
+  private safeNumber(v: any, fallback: number, onFallback?: () => void): number {
+    if (this.isFiniteNumber(v)) return v;
+    if (onFallback) onFallback();
+    return fallback;
+  }
+
+  private clampOffset(v: any): { value: number; clamped: boolean } {
+    let value = 0;
+    let clamped = false;
+    if (this.isFiniteNumber(v)) {
+      value = v;
+    } else {
+      value = 0; // default
+      clamped = false; // not a clamp per se, but we log separately as non-numeric
+    }
+    if (value < -365) { value = -365; clamped = true; }
+    if (value > 365) { value = 365; clamped = true; }
+    return { value, clamped };
   }
 }
-

--- a/api/src/application/usecases/ai-agent/__tests__/finalize-template-creation.usecase.spec.ts
+++ b/api/src/application/usecases/ai-agent/__tests__/finalize-template-creation.usecase.spec.ts
@@ -6,6 +6,9 @@ import { TemplateRecommendationService } from '../../../../domain/ai-agent/servi
 import { DomainException } from '../../../../domain/exceptions/domain.exception';
 import { ComplexityLevel } from '../../../../domain/ai-agent/entities/process-analysis.entity';
 
+import { TemplateDraftMapper } from '../../../services/ai-agent/template-draft-mapper.service';
+import { CreateProcessTemplateUseCase } from '../../process-template/create-process-template.usecase';
+
 describe('FinalizeTemplateCreationUseCase', () => {
   let useCase: FinalizeTemplateCreationUseCase;
   let sessionRepository: jest.Mocked<InterviewSessionRepository>;
@@ -61,6 +64,14 @@ describe('FinalizeTemplateCreationUseCase', () => {
             optimizeStepSequence: jest.fn(),
           },
         },
+        {
+          provide: TemplateDraftMapper,
+          useValue: { toCreateDtoFromDraft: jest.fn().mockReturnValue({ name: 'Test Template', stepTemplates: [] }) }
+        },
+        {
+          provide: CreateProcessTemplateUseCase,
+          useValue: { execute: jest.fn().mockResolvedValue({ id: 123, name: 'Test Template', stepTemplates: [] }) }
+        }
       ],
     }).compile();
 
@@ -248,7 +259,7 @@ describe('FinalizeTemplateCreationUseCase', () => {
       historyRepository.save.mockRejectedValue(new Error('Database error'));
 
       await expect(useCase.execute(validInput)).rejects.toThrow('Database error');
-      
+
       // Should not mark session as completed if history save fails
       expect(sessionRepository.markAsCompleted).not.toHaveBeenCalled();
     });

--- a/api/src/application/usecases/ai-agent/ai-agent.module.ts
+++ b/api/src/application/usecases/ai-agent/ai-agent.module.ts
@@ -20,6 +20,7 @@ import { AIConversationService } from '../../../domain/ai-agent/services/ai-conv
 import { OpenAIResponder } from '../../services/ai-agent/openai-responder.service';
 import { AIConfigService } from '../../../infrastructure/ai/ai-config.service';
 import { InfrastructureModule } from '../../../infrastructure/infrastructure.module';
+import { ProcessTemplateModule } from '../../../interfaces/controllers/process-template/process-template.module';
 import { WebSocketModule } from '../../../infrastructure/websocket/websocket.module';
 import { AICacheModule } from '../../../infrastructure/cache/cache.module';
 import { MonitoringModule } from '../../../infrastructure/monitoring/monitoring.module';
@@ -36,6 +37,7 @@ import { FeatureFlagService, AIFeatureFlagGuard } from '../../../infrastructure/
     MonitoringModule,
     QueueModule,
     KnowledgeBaseModule,
+    ProcessTemplateModule,
   ],
   controllers: [AIAgentController],
   providers: [

--- a/api/src/application/usecases/ai-agent/process-user-message.usecase.draft-save.spec.ts
+++ b/api/src/application/usecases/ai-agent/process-user-message.usecase.draft-save.spec.ts
@@ -1,0 +1,132 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProcessUserMessageUseCase } from './process-user-message.usecase';
+import { InterviewSessionRepository } from '../../../domain/ai-agent/repositories/interview-session.repository.interface';
+import { AI_CONVERSATION_RESPONDER, AIConversationResponder } from '../../interfaces/ai-agent/ai-conversation-responder.interface';
+import { ProcessAnalysisService } from '../../../domain/ai-agent/services/process-analysis.service';
+import { AIRateLimitService } from '../../../infrastructure/ai/ai-rate-limit.service';
+import { AIMonitoringService } from '../../../infrastructure/monitoring/ai-monitoring.service';
+import { BackgroundJobQueueInterface, JobType } from '../../../infrastructure/queue/background-job-queue.interface';
+import { SocketGateway } from '../../../infrastructure/websocket/socket.gateway';
+import { AICacheService } from '../../../infrastructure/cache/ai-cache.service';
+import { AIAuditService } from '../../../infrastructure/monitoring/ai-audit.service';
+import { LLMOutputParser } from '../../services/ai-agent/llm-output-parser.service';
+import { TemplateDraftMapper } from '../../services/ai-agent/template-draft-mapper.service';
+import { FeatureFlagService } from '../../../infrastructure/security/ai-feature-flag.guard';
+
+class FakeSession {
+  private conversation: any[] = [];
+  constructor(private id: string, private userId: number) {}
+  getSessionIdString() { return this.id; }
+  getUserId() { return this.userId; }
+  getStatus() { return 'active'; }
+  isExpired() { return false; }
+  getConversation() { return this.conversation; }
+  getContext() { return {}; }
+  getExtractedRequirements() { return []; }
+  addMessage(m: any) { this.conversation.push(m); }
+}
+
+describe('ProcessUserMessageUseCase – Draft Save (PR2)', () => {
+  let useCase: ProcessUserMessageUseCase;
+  let sessionRepository: any;
+  let responder: any;
+  let analysis: any;
+  let rate: any;
+  let mon: any;
+  let queue: any;
+  let socket: any;
+  let cache: any;
+  let audit: any;
+  let parser: any;
+  let mapper: any;
+  let flags: any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProcessUserMessageUseCase,
+        { provide: 'InterviewSessionRepository', useValue: { findById: jest.fn(), updateConversation: jest.fn(), updateGeneratedTemplate: jest.fn() } },
+        { provide: AI_CONVERSATION_RESPONDER, useValue: { processMessage: jest.fn() } },
+        { provide: ProcessAnalysisService, useValue: { calculateConversationProgress: jest.fn() } },
+        { provide: AIRateLimitService, useValue: { checkRateLimit: jest.fn().mockResolvedValue(true) } },
+        { provide: AIMonitoringService, useValue: { logUsage: jest.fn(), logAIRequest: jest.fn(), logAIError: jest.fn() } },
+        { provide: 'BackgroundJobQueue', useValue: { addJob: jest.fn().mockResolvedValue(undefined) } },
+        { provide: SocketGateway, useValue: { broadcastConversationUpdate: jest.fn(), notifyTemplateGenerated: jest.fn() } },
+        { provide: AICacheService, useValue: { cacheConversation: jest.fn().mockResolvedValue(undefined) } },
+        { provide: AIAuditService, useValue: { computeConversationHash: jest.fn().mockReturnValue('hash') } },
+        { provide: LLMOutputParser, useValue: { extractTemplateJson: jest.fn() } },
+        { provide: TemplateDraftMapper, useValue: { toSessionDraft: jest.fn() } },
+        { provide: FeatureFlagService, useValue: { isEnabled: jest.fn() } },
+      ],
+    }).compile();
+
+    useCase = module.get(ProcessUserMessageUseCase);
+    sessionRepository = module.get('InterviewSessionRepository');
+    responder = module.get(AI_CONVERSATION_RESPONDER);
+    analysis = module.get(ProcessAnalysisService);
+    rate = module.get(AIRateLimitService);
+    mon = module.get(AIMonitoringService);
+    queue = module.get('BackgroundJobQueue');
+    socket = module.get(SocketGateway);
+    cache = module.get(AICacheService);
+    audit = module.get(AIAuditService);
+    parser = module.get(LLMOutputParser);
+    mapper = module.get(TemplateDraftMapper);
+    flags = module.get(FeatureFlagService);
+  });
+
+  it('saves draft and notifies when feature flag ON and parse OK', async () => {
+    const session = new FakeSession('s1', 10);
+    sessionRepository.findById.mockResolvedValue(session);
+    responder.processMessage.mockResolvedValue({ response: 'hello```json\n{"schema":"ai_chat_process_template.v1","process_template_draft":{"name":"X","stepTemplates":[]}}\n```', tokenCount: 5 });
+    parser.extractTemplateJson.mockReturnValue({ ok: true, data: { schema: 'ai_chat_process_template.v1', process_template_draft: { name: 'X', stepTemplates: [] } } });
+    flags.isEnabled.mockReturnValue(true);
+    mapper.toSessionDraft.mockReturnValue({ name: 'X', steps: [], metadata: { generatedAt: new Date().toISOString(), confidence: 0.8, sources: [] } });
+
+    await useCase.execute({ sessionId: 's1', userId: 10, message: 'm' } as any);
+
+    expect(sessionRepository.updateGeneratedTemplate).toHaveBeenCalledWith('s1', expect.objectContaining({ name: 'X' }));
+    expect(socket.notifyTemplateGenerated).toHaveBeenCalled();
+  });
+
+  it('does not save when feature flag OFF', async () => {
+    const session = new FakeSession('s2', 10);
+    sessionRepository.findById.mockResolvedValue(session);
+    responder.processMessage.mockResolvedValue({ response: 'text', tokenCount: 3 });
+    parser.extractTemplateJson.mockReturnValue({ ok: true, data: { schema: 'ai_chat_process_template.v1', process_template_draft: { name: 'X', stepTemplates: [] } } });
+    flags.isEnabled.mockReturnValue(false);
+
+    await useCase.execute({ sessionId: 's2', userId: 10, message: 'm' } as any);
+
+    expect(sessionRepository.updateGeneratedTemplate).not.toHaveBeenCalled();
+    expect(socket.notifyTemplateGenerated).not.toHaveBeenCalled();
+  });
+
+  it('does not save when parse fails', async () => {
+    const session = new FakeSession('s3', 10);
+    sessionRepository.findById.mockResolvedValue(session);
+    responder.processMessage.mockResolvedValue({ response: 'no-json', tokenCount: 3 });
+    parser.extractTemplateJson.mockReturnValue({ ok: false, errors: ['MissingFence'] });
+    flags.isEnabled.mockReturnValue(true);
+
+    await useCase.execute({ sessionId: 's3', userId: 10, message: 'm' } as any);
+
+    expect(sessionRepository.updateGeneratedTemplate).not.toHaveBeenCalled();
+    expect(socket.notifyTemplateGenerated).not.toHaveBeenCalled();
+  });
+
+  it('swallows persistence errors and logs via monitoring', async () => {
+    const session = new FakeSession('s4', 10);
+    sessionRepository.findById.mockResolvedValue(session);
+    responder.processMessage.mockResolvedValue({ response: 'ok', tokenCount: 3 });
+    parser.extractTemplateJson.mockReturnValue({ ok: true, data: { schema: 'ai_chat_process_template.v1', process_template_draft: { name: 'X', stepTemplates: [] } } });
+    flags.isEnabled.mockReturnValue(true);
+    mapper.toSessionDraft.mockReturnValue({ name: 'X', steps: [], metadata: { generatedAt: new Date().toISOString(), confidence: 0.8, sources: [] } });
+    sessionRepository.updateGeneratedTemplate.mockRejectedValue(new Error('db error'));
+
+    await useCase.execute({ sessionId: 's4', userId: 10, message: 'm' } as any);
+
+    expect(mon.logAIError).toHaveBeenCalledWith(10, 'draft_save_error', expect.any(Error));
+  });
+});
+

--- a/api/src/application/usecases/ai-agent/process-user-message.usecase.ut2.spec.ts
+++ b/api/src/application/usecases/ai-agent/process-user-message.usecase.ut2.spec.ts
@@ -10,6 +10,9 @@ import { SocketGateway } from '../../../infrastructure/websocket/socket.gateway'
 import { AICacheService } from '../../../infrastructure/cache/ai-cache.service';
 import { AIAuditService } from '../../../infrastructure/monitoring/ai-audit.service';
 import { LLMOutputParser } from '../../services/ai-agent/llm-output-parser.service';
+import { TemplateDraftMapper } from '../../services/ai-agent/template-draft-mapper.service';
+import { FeatureFlagService } from '../../../infrastructure/security/ai-feature-flag.guard';
+
 import { DomainException } from '../../../domain/exceptions/domain.exception';
 
 class FakeMsg {
@@ -57,6 +60,8 @@ describe('ProcessUserMessageUseCase (Phase1 behavior)', () => {
         { provide: AIMonitoringService, useValue: { logUsage: jest.fn(), logAIRequest: jest.fn(), logAIError: jest.fn() } },
         { provide: 'BackgroundJobQueue', useValue: { addJob: jest.fn().mockResolvedValue(undefined) } },
         { provide: SocketGateway, useValue: { broadcastConversationUpdate: jest.fn() } },
+        { provide: TemplateDraftMapper, useValue: { toSessionDraft: jest.fn() } },
+        { provide: FeatureFlagService, useValue: { isEnabled: jest.fn().mockReturnValue(false) } },
         { provide: AICacheService, useValue: { cacheConversation: jest.fn().mockResolvedValue(undefined) } },
         { provide: AIAuditService, useValue: { computeConversationHash: jest.fn().mockReturnValue('hash') } },
         { provide: LLMOutputParser, useValue: { extractTemplateJson: jest.fn().mockReturnValue({ ok: true }) } },

--- a/api/src/infrastructure/security/ai-feature-flag.guard.ts
+++ b/api/src/infrastructure/security/ai-feature-flag.guard.ts
@@ -48,6 +48,8 @@ export class FeatureFlagService {
     // Default flags
     const defaultFlags = {
       'ai_agent': true,
+      // Keep both keys for compatibility. Controller uses 'ai_template_generation'.
+      'ai_template_generation': true,
       'template_generation': true,
       'entity_extraction': true,
       'web_search': true,

--- a/api/src/interfaces/controllers/ai-agent.controller.integration.spec.ts
+++ b/api/src/interfaces/controllers/ai-agent.controller.integration.spec.ts
@@ -1,0 +1,127 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../../app.module';
+import { PrismaService } from '@infrastructure/prisma/prisma.service';
+import { MockJwtAuthGuard, overrideAuthGuards } from '../../../test/mocks/auth.mock';
+import { TestDataFactory } from '../../../test/factories/test-data.factory';
+import { AIRateLimitGuard } from '../guards/ai-rate-limit.guard';
+import { AIFeatureFlagGuard } from '../../infrastructure/security/ai-feature-flag.guard';
+import { FeatureFlagService } from '../../infrastructure/security/ai-feature-flag.guard';
+
+// Seed helper
+async function seedSessionWithDraft(prisma: PrismaService, opts: { sessionId: string; userId: number; draft: any }) {
+  const now = new Date();
+  await prisma.aIInterviewSession.create({
+    data: {
+      sessionId: opts.sessionId,
+      userId: opts.userId,
+      status: 'active',
+      context: { industry: 'software', processType: 'development', goal: 'Finalize test' },
+      conversation: [],
+      extractedRequirements: [],
+      generatedTemplate: opts.draft,
+      createdAt: now,
+      updatedAt: now,
+      expiresAt: new Date(now.getTime() + 60 * 60 * 1000),
+    },
+  });
+}
+
+describe('AIAgentController (integration) – finalize', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  let createdUserId: number;
+  const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+  const draft = {
+    id: 'template-1',
+    name: 'Draft Name',
+    description: 'Draft description',
+    steps: [
+      { id: 's1', name: 'Step 1', description: 'desc', duration: 5, dependencies: [], artifacts: [], responsible: 'Team', criticalPath: false },
+      { id: 's2', name: 'Step 2', description: 'desc2', duration: 3, dependencies: [], artifacts: [], responsible: 'Team', criticalPath: false },
+    ],
+    confidence: 0.9,
+  };
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await overrideAuthGuards(
+      Test.createTestingModule({ imports: [AppModule] })
+    )
+      .overrideGuard(AIRateLimitGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(AIFeatureFlagGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+
+    prisma = app.get(PrismaService);
+    await app.init();
+
+    // Prepare user and clean state
+    const user = await TestDataFactory.createUser(prisma, { email: `finalize_user_${Date.now()}@example.com` });
+    createdUserId = user.id;
+
+    await prisma.aIInterviewSession.deleteMany({ where: { sessionId } });
+    // Clean any pre-existing templates named 'Draft Name' (delete stepTemplates first)
+    const existing = await prisma.processTemplate.findMany({ where: { name: 'Draft Name' }, include: { stepTemplates: true } });
+    for (const t of existing) {
+      await prisma.stepTemplate.deleteMany({ where: { processId: t.id } });
+      await prisma.processTemplate.delete({ where: { id: t.id } });
+    }
+
+    await seedSessionWithDraft(prisma, { sessionId, userId: createdUserId, draft });
+  });
+
+  afterAll(async () => {
+    // Cleanup
+    await prisma.aIInterviewSession.deleteMany({ where: { sessionId } });
+    // Delete stepTemplates first due to FK constraint
+    const templates = await prisma.processTemplate.findMany({ where: { name: 'Draft Name' }, include: { stepTemplates: true } });
+    for (const t of templates) {
+      await prisma.stepTemplate.deleteMany({ where: { processId: t.id } });
+      await prisma.processTemplate.delete({ where: { id: t.id } });
+    }
+    await prisma.user.deleteMany({ where: { id: createdUserId } });
+    await app.close();
+  });
+
+  it('POST /api/ai-agent/sessions/:sessionId/finalize-template should create ProcessTemplate and complete session', async () => {
+    // Mock authenticated user id used by guard
+    MockJwtAuthGuard.mockUserId = createdUserId;
+
+    const res = await request(app.getHttpServer())
+      .post(`/api/ai-agent/sessions/${sessionId}/finalize-template`)
+      .send({ templateId: draft.id, notes: 'integration' })
+      .expect(201);
+
+    // Response shape
+    expect(res.body).toMatchObject({
+      sessionId,
+      templateId: draft.id,
+      name: draft.name,
+      status: 'finalized',
+    });
+
+    // Check DB: template exists
+    const saved = await prisma.processTemplate.findFirst({ where: { name: draft.name }, include: { stepTemplates: true } });
+    expect(saved).toBeTruthy();
+    expect(saved?.stepTemplates?.length).toBeGreaterThanOrEqual(1);
+
+    // Check session completed
+    const session = await prisma.aIInterviewSession.findUnique({ where: { sessionId } });
+    expect(session?.status).toBe('completed');
+  });
+});
+

--- a/api/src/interfaces/controllers/process-template/process-template.module.ts
+++ b/api/src/interfaces/controllers/process-template/process-template.module.ts
@@ -15,5 +15,8 @@ import { UsersModule } from '@infrastructure/users/users.module';
       useClass: ProcessTemplateRepository,
     },
   ],
+  exports: [
+    CreateProcessTemplateUseCase,
+  ],
 })
 export class ProcessTemplateModule {}

--- a/docs/ver1.2/ai_agent_feature_flags_and_finalize.md
+++ b/docs/ver1.2/ai_agent_feature_flags_and_finalize.md
@@ -1,0 +1,77 @@
+# AI Agent v1.2 – Feature Flags と Finalize フロー
+
+このドキュメントは、AI Agent v1.2で導入したFeature FlagとDraft→Finalize（正式テンプレ登録）のフロー、および運用上の注意点をまとめます。
+
+## 1. Feature Flags
+
+- グローバル環境変数（接頭辞: `AI_FEATURE_`）でON/OFFを管理します。`FeatureFlagService`が `AI_FEATURE_` プレフィックスを読み込み、フラグ名を小文字化して内部管理します。
+- 代表フラグ
+  - `AI_FEATURE_TEMPLATE_DRAFT_SAVE` → 内部キー: `template_draft_save`
+    - 既定: OFF（未設定時）
+    - 意味: 会話処理（ProcessUserMessageUseCase）でLLMの構造化出力をDraftとしてセッションに保存し、必要に応じて通知します。
+  - `ai_agent`（デコレータ @FeatureFlag('ai_agent')）
+    - AI機能全体の有効化/無効化
+  - `ai_template_generation`（デコレータ @FeatureFlag('ai_template_generation')）
+    - Finalizeエンドポイント等、テンプレート生成系機能の有効化/無効化
+
+設定例（.env）
+
+```
+AI_FEATURE_TEMPLATE_DRAFT_SAVE=true
+```
+
+## 2. Draft保存（参考：PR2）
+
+- トリガ: LLM応答の末尾JSON（ai_chat_process_template.v1）が正しくパースされた場合
+- 処理: TemplateDraftMapper.toSessionDraft() → InterviewSessionRepository.updateGeneratedTemplate()
+- 通知: SocketGateway.notifyTemplateGenerated()（必要に応じて）
+- 互換性: APIレスポンスは従来どおり。Draftのみセッションに保存。
+
+## 3. Finalize（PR3）
+
+- エンドポイント: POST /api/ai-agent/sessions/:sessionId/finalize-template
+- ガード/フラグ: JwtAuthGuard, AIRateLimitGuard, AIFeatureFlagGuard + @FeatureFlag('ai_template_generation')
+- フロー:
+  1) セッションからDraft取得（なければエラー）
+  2) modifications（name/description、軽微なsteps上書き）を適用
+  3) TemplateRecommendationServiceでvalidate/optimize
+  4) TemplateDraftMapper.toCreateDtoFromDraft()でCreate DTO生成
+  5) CreateProcessTemplateUseCase.execute()で正式テンプレ作成
+  6) TemplateGenerationHistoryRepository.save()で履歴保存（processTemplateId, wasUsed, modifications等）
+  7) InterviewSessionRepository.markAsCompleted()でセッション完了
+  8) FinalizeTemplateResponseDtoを返却（templateIdは入力のtemplateIdを返却）
+
+レスポンス例
+
+```
+{
+  "templateId": "template-1",
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "Draft Name",
+  "description": "Draft description",
+  "steps": [...],
+  "metadata": { "version": "1.0", "createdBy": "AI Agent" },
+  "createdAt": "2025-09-09T00:00:00.000Z",
+  "status": "finalized"
+}
+```
+
+## 4. 運用ノート
+
+- 既存互換性: Feature FlagがOFF、またはDraft不在の場合は従来と同等の挙動（Finalizeはエラー応答）。
+- 監査/監視: Finalize成功/失敗のログが記録されます。エラー時のログキーは実装に準拠。
+- ネーミング競合: CreateProcessTemplateUseCaseは名前重複でConflictException。UI側での名称調整または再入力が必要。
+- セッションクリーンアップ: 完了済みセッションのDraft保持/削除は運用方針に依存（現状保持）。
+
+## 5. テスト
+
+- UseCase UT: finalize-template-creation.usecase.spec.ts
+- Controller統合テスト: ai-agent.controller.integration.spec.ts
+  - 事前にAIInterviewSessionへDraftをseed
+  - エンドポイント呼び出し後、ProcessTemplate作成とセッション完了を検証
+
+## 6. 既知の課題/拡張
+
+- modificationsの適用範囲は最小（name/description＋stepsの軽微上書き・新規追加）。
+- ステップ削除/並び替え/依存関係再構成など大規模編集は別Issueで要検討。
+


### PR DESCRIPTION
目的
- PR1: TemplateDraftMapper 実装＋UT（ai_chat ⇄ Draft ⇄ Create DTO）
- PR2: 会話処理でのDraft保存と通知をFeature Flagで制御して導入
- PR3: DraftのFinalizeで正式テンプレ登録（CreateProcessTemplateUseCaseを利用）

このPRでは、v1.2接続の第一〜第三段を同一ブランチで積み上げています（分割が必要であればご指示ください）。

変更点（追加分：PR3）
- FinalizeTemplateCreationUseCase
  - Session Draft取得 → modifications反映（name/description＋軽微なsteps上書き）
  - validate/optimize 実施後、TemplateDraftMapper.toCreateDtoFromDraft() で DTO化
  - CreateProcessTemplateUseCase.execute() で正式テンプレ作成
  - 履歴保存（processTemplateId付与, wasUsed=true, modifications記録）
  - セッション完了（markAsCompleted）
  - FinalizeTemplateResponseDto 整形（templateIdは入力のtemplateIdを返却）
- DI/Module調整
  - ProcessTemplateModuleからCreateProcessTemplateUseCaseをexports
  - AIAgentModuleでProcessTemplateModuleをimports
- テスト
  - UseCase UT: finalize-template-creation.usecase.spec.ts 追加/更新
  - Controller統合テスト: ai-agent.controller.integration.spec.ts 追加（Draft seed→Finalize→DB/セッション検証）
- ドキュメント
  - docs/ver1.2/ai_agent_feature_flags_and_finalize.md 追加（Feature FlagとFinalize運用ガイド）

影響範囲
- API/DTO/DB schema 変更なし
- 既存機能非破壊（Feature Flagオフ時は従来通り / FinalizeはDraftが存在する時のみ動作）

レビュー観点
- modificationsの適用範囲（現状は最小）
- FinalizeレスポンスのtemplateIdの扱い（入力templateIdを返す設計に追従）

関連
- Relates to #55（v1.2 実装タスク）

備考
- stepsの大規模編集が必要な場合は、仕様確定のうえ別PRでの対応を提案します。